### PR TITLE
Hierarchicalcluster fix

### DIFF
--- a/README.md
+++ b/README.md
@@ -7,7 +7,7 @@ Tools and functions for neural acoustic data processing and analysis in python
 To install or update this package through pip, run the following command:
 
 ```bash
-pip install git+https://github.com/gavinmischler/naplib-python.git
+pip install git+https://github.com/naplab/naplib-python.git
 ```
 
 ## API

--- a/naplib/visualization/plots.py
+++ b/naplib/visualization/plots.py
@@ -91,9 +91,9 @@ def hierarchicalclusterplot(data, axes=None, varnames=None, cmap='bwr', n_cluste
         mm1 = np.abs(data.reshape((-1)).min())
         mm2 = np.abs(data.reshape((-1)).max())
         mm = max([mm1, mm2])
-        axes[1].imshow(data[leaves,:].T, cmap=cmap, aspect=4, vmin=-mm, vmax=mm)
+        axes[1].imshow(data[leaves,:].T, cmap=cmap, aspect=4, vmin=-mm, vmax=mm, interpolation='none')
     else:
-        axes[1].imshow(data[leaves,:].T, cmap=cmap, aspect=4)
+        axes[1].imshow(data[leaves,:].T, cmap=cmap, aspect=4, interpolation='none')
     if varnames:
         axes[1].set_yticks([i for i in range(len(varnames))])
         axes[1].set_yticklabels(varnames, fontsize=8)


### PR DESCRIPTION
<!--
Thanks for contributing a pull request to naplib-python!
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.
The imshow portion in hierarchical cluster plot uses the default interpolation from plt.imshow, which is not the desired default behavior since it smooths out information unnecessarily. This sets interpolation='none' in the imshow() call.

#### Any other comments?
