### PR TITLE
Fix join_fields exception message

### DIFF
--- a/naplib/out_struct.py
+++ b/naplib/out_struct.py
@@ -253,7 +253,7 @@ def join_fields(outstructs, fieldname='resp', axis=-1, return_outstruct=False):
             raise TypeError(f'All inputs must be an OutStruct but found {type(out)}')
         field = out.get_field(fieldname)
         if not isinstance(field[0], np.ndarray):
-            raise TypeError(f'Can only concatenate np.ndarrays, but found {type(starting_field[0])} in this field')
+            raise TypeError(f'Can only concatenate np.ndarrays, but found {type(field[0])} in this field')
 
     starting_fields = [out.get_field(fieldname) for out in outstructs] # each one should be a list of np.arrays
     


### PR DESCRIPTION
<!--
Thanks for contributing a pull request to naplib-python!
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Fixes #5 

#### What does this implement/fix? Explain your changes.
the error message tried to print a value that hadn't been set yet, which would throw another error of its own, so this fixes that.

#### Any other comments?
