### PR TITLE
Add data files to fix auditory spec and alignment

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -29,9 +29,10 @@ Change tags (adopted from `sklearn <https://scikit-learn.org/stable/whats_new/v0
 - |API| : you will need to change your code to have the same effect in the future; or a feature will be removed in the future.
 
 
-In Development
---------------
+Version 0.1.2
+-------------
 
+- |Fix| : Fixed issue where data files required to properly use ``features.auditory_spectrogram`` and ``features.Aligner`` were not being included in the pip-installable package.
 - |Fix| : Changed ``preprocessing.normalize`` function to properly allow ``axis=None`` to specify normalizing by global statistics, and updated the documentation accordingly.
 
 

--- a/naplib/__init__.py
+++ b/naplib/__init__.py
@@ -10,4 +10,4 @@ import naplib.model_selection
 import naplib.utils
 from .data import Data, join_fields
 
-__version__ = "0.1.1"
+__version__ = "0.1.2"

--- a/setup.py
+++ b/setup.py
@@ -29,6 +29,11 @@ def check_python_version():
     if sys.version_info < MINIMUM_PYTHON_VERSION:
         sys.exit("Python {}.{}+ is required.".format(*MINIMUM_PYTHON_VERSION))
 
+non_python_files = ['features/*.mat',
+                    'features/eng.*',
+                    'features/resample.sh',
+                    'features/prosodylab_aligner/LICENSE'
+                    ]
 
 check_python_version()
 
@@ -58,5 +63,6 @@ setup(
         "Programming Language :: Python :: 3.10"
     ],
     packages=find_packages(),
+    package_data={'naplib': non_python_files},
     include_package_data=True,
 )


### PR DESCRIPTION
<!--
Thanks for contributing a pull request to naplib-python!
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.
Fixes issue where data files required for auditory spectrogram and alignment in the features module were not package with the pip-installable tarball.

#### Any other comments?
