### PR TITLE
Update fileio.py

### DIFF
--- a/naplib/io/fileio.py
+++ b/naplib/io/fileio.py
@@ -52,23 +52,27 @@ def import_outstruct(filepath, strict=True, verbose=False):
             if np.prod(tmp.shape) == 1:
                 tmp = tmp[0,0]
             else:
-                # Read cell arrays within entries
-                if isinstance(tmp[0,0], h5py.h5r.Reference):
-                    shp = tmp.shape
-                    tmp_flat = np.ravel(tmp)
-                    for tt in range(len(tmp_flat)):
-                        # Handle cell arrays containing strings
+                try:
+                    tmp = ''.join([chr(c[0]) for c in tmp])
+                    print(fld, tmp)
+                except:
+                    # Read cell arrays within entries
+                    if isinstance(tmp[0,0], h5py.h5r.Reference):
+                        shp = tmp.shape
+                        tmp_flat = np.ravel(tmp)
+                        for tt in range(len(tmp_flat)):
+                            # Handle cell arrays containing strings
+                            try:
+                                tmp_flat[tt] = ''.join([chr(c[0]) for c in f[tmp_flat[tt]][:]])
+                            except:
+                                tmp_flat[tt] = f[tmp_flat[tt]][:]
+                        tmp = np.reshape(tmp_flat, shp)
+                        # Remove lists encapsulating single values
                         try:
-                            tmp_flat[tt] = ''.join([chr(c[0]) for c in f[tmp_flat[tt]][:]])
+                            while len(tmp) == 1:
+                                tmp = tmp[0]
                         except:
-                            tmp_flat[tt] = f[tmp_flat[tt]][:]
-                    tmp = np.reshape(tmp_flat, shp)
-                    # Remove lists encapsulating single values
-                    try:
-                        while len(tmp) == 1:
-                            tmp = tmp[0]
-                    except:
-                        pass
+                            pass
 
             if f == 'resp' or f == 'aud':
                 if tmp.ndim > 1:

--- a/naplib/io/fileio.py
+++ b/naplib/io/fileio.py
@@ -24,6 +24,10 @@ def import_outstruct(filepath, strict=True, useloadmat=True, verbose=False):
         1) Each trial must contain at least the following fields:
         ['name','sound','soundf','resp','dataf']
         2) Each trial must contain the exact same set of fields
+    useloadmat : boolean, default=True
+        If True, use hdf5storage.loadmat, else use custom h5py loader
+    verbose : boolean, default=False
+        If True, print trial number and field as it's loaded
 
     Returns
     -------
@@ -42,9 +46,10 @@ def import_outstruct(filepath, strict=True, useloadmat=True, verbose=False):
         loaded = loaded['out'].squeeze()
         fieldnames = loaded[0].dtype.names
 
-        for trial in loaded:
+        for tt,trial in enumerate(loaded):
             trial_dict = {}
             for f, t in zip(fieldnames, trial):
+                if verbose: print(tt, f)
                 tmp_t = t.squeeze()
                 if f == 'resp' or f == 'aud':
                     if tmp_t.ndim > 1:

--- a/naplib/io/fileio.py
+++ b/naplib/io/fileio.py
@@ -9,7 +9,7 @@ from ..data import Data
 
 ACCEPTED_CROP_BY = ['onset', 'durations']
 
-def import_outstruct(filepath, strict=True):
+def import_outstruct(filepath, strict=True, verbose=False):
     '''
     Import out struct from matlab (.mat) format. This will
     automatically transpose the 'resp' and 'aud' fields
@@ -46,7 +46,7 @@ def import_outstruct(filepath, strict=True):
     for trial in range(n_trial):
         trial_dict = {}
         for fld in fieldnames:
-            print(trial, fld)
+            if verbose: print(trial, fld)
             tmp = np.array(f[f['out'][fld][trial][0]])
             # Pull out scalars
             if np.prod(tmp.shape) == 1:

--- a/naplib/io/fileio.py
+++ b/naplib/io/fileio.py
@@ -46,9 +46,30 @@ def import_outstruct(filepath, strict=True):
     for trial in range(n_trial):
         trial_dict = {}
         for fld in fieldnames:
+            print(trial, fld)
             tmp = np.array(f[f['out'][fld][trial][0]])
+            # Pull out scalars
             if np.prod(tmp.shape) == 1:
                 tmp = tmp[0,0]
+            else:
+                # Read cell arrays within entries
+                if isinstance(tmp[0,0], h5py.h5r.Reference):
+                    shp = tmp.shape
+                    tmp_flat = np.ravel(tmp)
+                    for tt in range(len(tmp_flat)):
+                        # Handle cell arrays containing strings
+                        try:
+                            tmp_flat[tt] = ''.join([chr(c[0]) for c in f[tmp_flat[tt]][:]])
+                        except:
+                            tmp_flat[tt] = f[tmp_flat[tt]][:]
+                    tmp = np.reshape(tmp_flat, shp)
+                    # Remove lists encapsulating single values
+                    try:
+                        while len(tmp) == 1:
+                            tmp = tmp[0]
+                    except:
+                        pass
+
             if f == 'resp' or f == 'aud':
                 if tmp.ndim > 1:
                     tmp = tmp.transpose(1,0,*[i for i in range(2, tmp.ndim)]) # only switch the first 2 dimensions if there are more than 2

--- a/naplib/io/fileio.py
+++ b/naplib/io/fileio.py
@@ -76,7 +76,6 @@ def import_outstruct(filepath, strict=True, useloadmat=True, verbose=False):
                 else:
                     try:
                         tmp = ''.join([chr(c[0]) for c in tmp])
-                        print(fld, tmp)
                     except:
                         # Read cell arrays within entries
                         if isinstance(tmp[0,0], h5py.h5r.Reference):

--- a/naplib/io/fileio.py
+++ b/naplib/io/fileio.py
@@ -45,14 +45,14 @@ def import_outstruct(filepath, strict=True):
     data = []
     for trial in range(n_trial):
         trial_dict = {}
-        for f in fieldnames:
-            tmp = np.array(f[f['out'][fld][trl][0]])
+        for fld in fieldnames:
+            tmp = np.array(f[f['out'][fld][trial][0]])
             if np.prod(tmp.shape) == 1:
                 tmp = tmp[0,0]
             if f == 'resp' or f == 'aud':
                 if tmp.ndim > 1:
                     tmp = tmp.transpose(1,0,*[i for i in range(2, tmp.ndim)]) # only switch the first 2 dimensions if there are more than 2
-            trial_dict[f] = tmp
+            trial_dict[fld] = tmp
         data.append(trial_dict)
     
     for r in req:

--- a/naplib/io/fileio.py
+++ b/naplib/io/fileio.py
@@ -95,9 +95,6 @@ def import_outstruct(filepath, strict=True, useloadmat=True, verbose=False):
                             except:
                                 pass
 
-                if fld == 'aud':
-                    if tmp.ndim > 1:
-                        tmp = tmp.transpose(1,0,*[i for i in range(2, tmp.ndim)]) # only switch the first 2 dimensions if there are more than 2
                 trial_dict[fld] = tmp
             data.append(trial_dict)
     

--- a/naplib/io/fileio.py
+++ b/naplib/io/fileio.py
@@ -94,8 +94,9 @@ def import_outstruct(filepath, strict=True, useloadmat=True, verbose=False):
                                     tmp = tmp[0]
                             except:
                                 pass
+                        tmp = np.squeeze(tmp)
 
-                trial_dict[fld] = np.squeeze(tmp)
+                trial_dict[fld] = tmp
             data.append(trial_dict)
     
     for r in req:

--- a/naplib/io/fileio.py
+++ b/naplib/io/fileio.py
@@ -36,6 +36,7 @@ def import_outstruct(filepath, strict=True, useloadmat=True, verbose=False):
     Lab members.
     '''
     req = ['name','sound','soundf','resp','dataf']
+    data = []
     if useloadmat:
         loaded = loadmat(filepath)
         loaded = loaded['out'].squeeze()
@@ -59,7 +60,6 @@ def import_outstruct(filepath, strict=True, useloadmat=True, verbose=False):
         fieldnames = list(f['out'].keys())
         n_trial = f['out'][fieldnames[0]].shape[0]
     
-        data = []
         for trial in range(n_trial):
             trial_dict = {}
             for fld in fieldnames:

--- a/naplib/io/fileio.py
+++ b/naplib/io/fileio.py
@@ -87,7 +87,7 @@ def import_outstruct(filepath, strict=True, useloadmat=True, verbose=False):
                                     tmp_flat[tt] = ''.join([chr(c[0]) for c in f[tmp_flat[tt]][:]])
                                 except:
                                     tmp_flat[tt] = f[tmp_flat[tt]][:]
-                            tmp = np.squeeze(np.reshape(tmp_flat, shp))
+                            tmp = np.reshape(tmp_flat, shp)
                             # Remove lists with single item
                             try:
                                 while len(tmp) == 1:
@@ -95,7 +95,7 @@ def import_outstruct(filepath, strict=True, useloadmat=True, verbose=False):
                             except:
                                 pass
 
-                trial_dict[fld] = tmp
+                trial_dict[fld] = np.squeeze(tmp)
             data.append(trial_dict)
     
     for r in req:

--- a/naplib/io/fileio.py
+++ b/naplib/io/fileio.py
@@ -91,7 +91,7 @@ def import_outstruct(filepath, strict=True, useloadmat=True, verbose=False):
                             except:
                                 pass
 
-                if fld == 'resp' or fld == 'aud':
+                if fld == 'aud':
                     if tmp.ndim > 1:
                         tmp = tmp.transpose(1,0,*[i for i in range(2, tmp.ndim)]) # only switch the first 2 dimensions if there are more than 2
                 trial_dict[fld] = tmp

--- a/naplib/io/fileio.py
+++ b/naplib/io/fileio.py
@@ -87,7 +87,7 @@ def import_outstruct(filepath, strict=True, useloadmat=True, verbose=False):
                                     tmp_flat[tt] = ''.join([chr(c[0]) for c in f[tmp_flat[tt]][:]])
                                 except:
                                     tmp_flat[tt] = f[tmp_flat[tt]][:]
-                            tmp = np.reshape(tmp_flat, shp)
+                            tmp = np.squeeze(np.reshape(tmp_flat, shp))
                             # Remove lists with single item
                             try:
                                 while len(tmp) == 1:

--- a/requirements.txt
+++ b/requirements.txt
@@ -6,3 +6,4 @@ statsmodels>=0.13.0
 hdf5storage>=0.1.1
 scikit-learn
 mne
+h5py

--- a/tests/io/test_fileio.py
+++ b/tests/io/test_fileio.py
@@ -41,7 +41,7 @@ def test_import_Data_works():
     thisfile = os.path.dirname(__file__)
     data = import_outstruct(f'{thisfile}/../../naplib/io/sample_data/demo_data.mat')
     assert isinstance(data, Data)
-    data = import_outstruct(f'{thisfile}/../../naplib/io/sample_data/demo_data.mat', useloadmat=False)
+    data = import_outstruct(f'{thisfile}/../../naplib/io/sample_data/demo_data_v73.mat', useloadmat=False)
     assert isinstance(data, Data)
 
 def test_import_Data_fields():
@@ -56,7 +56,7 @@ def test_import_Data_fields():
     assert np.allclose(data[-1]['befaft'], np.array([1, 1], dtype='uint8'))
     assert np.allclose(data['sound'][0][20000:20005], np.array([-0.04907227, -0.04403687, -0.03979492, -0.03573608, -0.03210449]))
 
-    data = import_outstruct(f'{thisfile}/../../naplib/io/sample_data/demo_data.mat', useloadmat=False)
+    data = import_outstruct(f'{thisfile}/../../naplib/io/sample_data/demo_data_v73.mat', useloadmat=False)
     assert all(x==y for x, y in zip(data.fields, ['name','sound','soundf','dataf','duration','befaft','resp','aud','script']))
     assert data[1]['name'] == 'stim02'
     assert data[1]['resp'].shape == (5203, 10)

--- a/tests/io/test_fileio.py
+++ b/tests/io/test_fileio.py
@@ -57,7 +57,7 @@ def test_import_Data_fields():
     assert np.allclose(data['sound'][0][20000:20005], np.array([-0.04907227, -0.04403687, -0.03979492, -0.03573608, -0.03210449]))
 
     data = import_outstruct(f'{thisfile}/../../naplib/io/sample_data/demo_data_v73.mat', useloadmat=False)
-    assert all(x==y for x, y in zip(data.fields, ['name','sound','soundf','dataf','duration','befaft','resp','aud','script']))
+    assert all(x==y for x, y in zip(set(data.fields), set(['name','sound','soundf','dataf','duration','befaft','resp','aud','script'])))
     assert data[1]['name'] == 'stim02'
     assert data[1]['resp'].shape == (5203, 10)
     assert data[1]['aud'].shape == (5203, 128)

--- a/tests/io/test_fileio.py
+++ b/tests/io/test_fileio.py
@@ -39,14 +39,16 @@ def test_load_no_file():
 
 def test_import_Data_works():
     thisfile = os.path.dirname(__file__)
-    data = import_outstruct(f'{thisfile}/../../naplib/io/sample_data/demo_data.mat')
+    fn = f'{thisfile}/../../naplib/io/sample_data/demo_data.mat'
+    data = import_outstruct(fn)
     assert isinstance(data, Data)
-    data = import_outstruct(f'{thisfile}/../../naplib/io/sample_data/demo_data_v73.mat', useloadmat=False)
+    data = import_outstruct(fn, useloadmat=False)
     assert isinstance(data, Data)
 
 def test_import_Data_fields():
     thisfile = os.path.dirname(__file__)
-    data = import_outstruct(f'{thisfile}/../../naplib/io/sample_data/demo_data.mat')
+    fn = f'{thisfile}/../../naplib/io/sample_data/demo_data.mat'
+    data = import_outstruct(fn)
     assert all(x==y for x, y in zip(data.fields, ['name','sound','soundf','dataf','duration','befaft','resp','aud','script']))
     assert data[1]['name'] == 'stim02'
     assert data[1]['resp'].shape == (5203, 10)
@@ -56,7 +58,7 @@ def test_import_Data_fields():
     assert np.allclose(data[-1]['befaft'], np.array([1, 1], dtype='uint8'))
     assert np.allclose(data['sound'][0][20000:20005], np.array([-0.04907227, -0.04403687, -0.03979492, -0.03573608, -0.03210449]))
 
-    data = import_outstruct(f'{thisfile}/../../naplib/io/sample_data/demo_data_v73.mat', useloadmat=False)
+    data = import_outstruct(fn, useloadmat=False)
     assert all(x==y for x, y in zip(set(data.fields), set(['name','sound','soundf','dataf','duration','befaft','resp','aud','script'])))
     assert data[1]['name'] == 'stim02'
     assert data[1]['resp'].shape == (5203, 10)

--- a/tests/io/test_fileio.py
+++ b/tests/io/test_fileio.py
@@ -59,7 +59,7 @@ def test_import_Data_fields():
     assert np.allclose(data['sound'][0][20000:20005], np.array([-0.04907227, -0.04403687, -0.03979492, -0.03573608, -0.03210449]))
 
     data = import_outstruct(fn, useloadmat=False)
-    assert all(x==y for x, y in zip(set(data.fields), set(['name','sound','soundf','dataf','duration','befaft','resp','aud','script'])))
+    assert set(data.fields==set(['name','sound','soundf','dataf','duration','befaft','resp','aud','script']))
     assert data[1]['name'] == 'stim02'
     assert data[1]['resp'].shape == (5203, 10)
     assert data[1]['aud'].shape == (5203, 128)

--- a/tests/io/test_fileio.py
+++ b/tests/io/test_fileio.py
@@ -59,7 +59,7 @@ def test_import_Data_fields():
     assert np.allclose(data['sound'][0][20000:20005], np.array([-0.04907227, -0.04403687, -0.03979492, -0.03573608, -0.03210449]))
 
     data = import_outstruct(fn, useloadmat=False)
-    assert set(data.fields==set(['name','sound','soundf','dataf','duration','befaft','resp','aud','script']))
+    assert set(data.fields)==set(['name','sound','soundf','dataf','duration','befaft','resp','aud','script'])
     assert data[1]['name'] == 'stim02'
     assert data[1]['resp'].shape == (5203, 10)
     assert data[1]['aud'].shape == (5203, 128)

--- a/tests/io/test_fileio.py
+++ b/tests/io/test_fileio.py
@@ -49,22 +49,24 @@ def test_import_Data_fields():
     thisfile = os.path.dirname(__file__)
     fn = f'{thisfile}/../../naplib/io/sample_data/demo_data.mat'
     data = import_outstruct(fn)
-    assert all(x==y for x, y in zip(data.fields, ['name','sound','soundf','dataf','duration','befaft','resp','aud','script']))
+    assert all(x==y for x, y in zip(data.fields, ['name','sound','soundf','dataf','duration','befaft','resp','aud','script','chname']))
     assert data[1]['name'] == 'stim02'
     assert data[1]['resp'].shape == (5203, 10)
     assert data[1]['aud'].shape == (5203, 128)
     assert np.allclose(data[1]['resp'][:5,2], np.array([0.17288463, 0.27798367, 0.42636263, 0.46837241, 0.42326083]))
     assert data[0]['script'][:5] == 'IT IS'
+    assert data[0]['chname'][2] == 'Fz'
     assert np.allclose(data[-1]['befaft'], np.array([1, 1], dtype='uint8'))
     assert np.allclose(data['sound'][0][20000:20005], np.array([-0.04907227, -0.04403687, -0.03979492, -0.03573608, -0.03210449]))
 
     data = import_outstruct(fn, useloadmat=False)
-    assert set(data.fields)==set(['name','sound','soundf','dataf','duration','befaft','resp','aud','script'])
+    assert set(data.fields)==set(['name','sound','soundf','dataf','duration','befaft','resp','aud','script','chname'])
     assert data[1]['name'] == 'stim02'
     assert data[1]['resp'].shape == (5203, 10)
     assert data[1]['aud'].shape == (5203, 128)
     assert np.allclose(data[1]['resp'][:5,2], np.array([0.17288463, 0.27798367, 0.42636263, 0.46837241, 0.42326083]))
     assert data[0]['script'][:5] == 'IT IS'
+    assert data[0]['chname'][2] == 'Fz'
     assert np.allclose(data[-1]['befaft'], np.array([1, 1], dtype='uint8'))
     assert np.allclose(data['sound'][0][20000:20005], np.array([-0.04907227, -0.04403687, -0.03979492, -0.03573608, -0.03210449]))
 

--- a/tests/io/test_fileio.py
+++ b/tests/io/test_fileio.py
@@ -41,10 +41,22 @@ def test_import_Data_works():
     thisfile = os.path.dirname(__file__)
     data = import_outstruct(f'{thisfile}/../../naplib/io/sample_data/demo_data.mat')
     assert isinstance(data, Data)
+    data = import_outstruct(f'{thisfile}/../../naplib/io/sample_data/demo_data.mat', useloadmat=False)
+    assert isinstance(data, Data)
 
 def test_import_Data_fields():
     thisfile = os.path.dirname(__file__)
     data = import_outstruct(f'{thisfile}/../../naplib/io/sample_data/demo_data.mat')
+    assert all(x==y for x, y in zip(data.fields, ['name','sound','soundf','dataf','duration','befaft','resp','aud','script']))
+    assert data[1]['name'] == 'stim02'
+    assert data[1]['resp'].shape == (5203, 10)
+    assert data[1]['aud'].shape == (5203, 128)
+    assert np.allclose(data[1]['resp'][:5,2], np.array([0.17288463, 0.27798367, 0.42636263, 0.46837241, 0.42326083]))
+    assert data[0]['script'][:5] == 'IT IS'
+    assert np.allclose(data[-1]['befaft'], np.array([1, 1], dtype='uint8'))
+    assert np.allclose(data['sound'][0][20000:20005], np.array([-0.04907227, -0.04403687, -0.03979492, -0.03573608, -0.03210449]))
+
+    data = import_outstruct(f'{thisfile}/../../naplib/io/sample_data/demo_data.mat', useloadmat=False)
     assert all(x==y for x, y in zip(data.fields, ['name','sound','soundf','dataf','duration','befaft','resp','aud','script']))
     assert data[1]['name'] == 'stim02'
     assert data[1]['resp'].shape == (5203, 10)


### PR DESCRIPTION
Updated import_outstruct to use h5py instead of hdf5storage.

#### What does this implement/fix? Explain your changes.
Should be faster for larger files and outstructs containing cell arrays

#### Any other comments?
May have trouble if the outstructs contain nested matlab data structures (cell within a cell within the outstruct field), but it should be able to handle un-nested matlab data structures and arrays

Assumes a field containing a vector of integers is an encoded string