### PR TITLE
Errorplot

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -35,6 +35,8 @@ In Development - Version 0.1.3
 - |API| : The ``import_outstruct`` function has been renamed ``import_data`` to better imply that a Data object is returned.
 - |Efficiency| : The ``import_data`` function can now optionally use h5py under the hood, rather than hdf5storage, which makes loading large Data objects from MATLAB significantly faster.
 - |Feature| : Added the ``export_data`` function which can be used to export Data objects as MATLAB-compatible (.mat) files, the same file structures which are read in by the ``import_data`` function.
+- |Enhancement| : Added the ability to pass format strings (such as 'r--' to indicate red, dashed lines) to ``visualization.shadederrorplot`` so that the API matches that of matplotlib's Axes.plot.
+
 
 
 Version 0.1.2

--- a/naplib/visualization/plots.py
+++ b/naplib/visualization/plots.py
@@ -10,9 +10,10 @@ def shadederrorplot(*args, ax=None, err_method='stderr', color=None, alpha=0.4, 
     '''
     Parameters
     ----------
-    x, y : array-like (time,), (time, n_samples)
-        Data to plot, providing the horixontal / vertical coordinates. *x* values
-        are optional and default to ``range(len(y))``. *y* values should be
+    x : array-like, shape (n_samples,), optional
+        *x* values are optional and default to ``range(len(y))``.
+    y : array-like, shape (n_samples, n_lines)
+        Data to plot, providing the vertical coordinates. *y* values should be
         two-dimensional, and statistics used to compute shaded region interval
         are computed over the second dimension.
     fmt : str, optional

--- a/naplib/visualization/plots.py
+++ b/naplib/visualization/plots.py
@@ -6,32 +6,55 @@ import matplotlib.pyplot as plt
 from scipy import signal as sig
 
 
-def shadederrorplot(x, y, ax=None, err_method='stderr', plt_args={}, shade_args={}, nan_policy='omit'):
+def shadederrorplot(*args, ax=None, err_method='stderr', color=None, alpha=0.4, plt_args={}, shade_args={}, nan_policy='omit'):
     '''
     Parameters
     ----------
-    x : shape (time,)
-        Values to use as x-index
-    y : shape (time, n_samples)
-        Data to plot. The average over the n_samples will be plotted on the main
-        line, surrounded by a shaded region determined by the ``err_method`` parameter.
+    x, y : array-like (time,), (time, n_samples)
+        Data to plot, providing the horixontal / vertical coordinates. *x* values
+        are optional and default to ``range(len(y))``. *y* values should be
+        two-dimensional, and statistics used to compute shaded region interval
+        are computed over the second dimension.
+    fmt : str, optional
+        A format string, e.g. 'ro' for red circles. See the matplotlib
+        `Axes.plot <https://matplotlib.org/stable/api/_as_gen/matplotlib.axes.Axes.plot.html>`_
+        Notes section for a full description of the format strings.
+        Format strings are just an abbreviation for quickly setting
+        basic line properties. All of these and more can also be
+        controlled by keyword arguments within color or plt_args.
+        This argument cannot be passed as keyword.
     ax : plt.Axes instance, optional
         Axes to use. If not specified, will use current axes.
+    color : str, default=None
+        Color to plot line and shaded region. Defaults to next color in color cycle.
+    alpha : float, default=0.4
+        Shading alpha. Value between 0 and 1.
     err_method : string, default='stderr
         One of ['stderr','std'], the method to use to calculate error bars.
     plt_args : dict, default={}
-        Args to be passed to plt.plot(). e.g. 'color','linewidth',...
+        Dict of args to be passed to plt.plot(). e.g. {'linewidth': 2}, etc.
     shade_args : dict, default={}
-        Args to be passed to plt.fill_between(). e.g. 'color','alpha',...
+        Dict of args to be passed to plt.fill_between(). e.g. {'alpha': 0.2}, etc.
     nan_policy : string, default='omit'
         One of ['omit','raise','propogate']. If 'omit', will ignore any nan in the
         inputs, if 'raise', will raise a ValueError if nan is found in input, if
         'propogate', do not do anything special with nan values.
-        
+    
+    Examples
+    --------
+    >>> from naplib.visualization import shadederrorplot as sep
+    >>> import matplotlib.pyplot as plt
+    >>> x, y = np.linspace(0, 1, 10), np.random.rand(10,5)
+    >>> fig, ax = plt.subplots()
+    >>> sep(y) # plot mean of y vs x, with shaded error regions
+    >>> sep(y, 'r--') # same plot but color is red and line is dashed
+    >>> sep(x, y) # same plot but against specific x values
+    >>> plt.show()
+    
     Raises
     ------
     ValueError
-        if nan found in input
+        if nan found in input and ``nan_policy`` is 'raise'.
     '''
     if nan_policy not in ['omit','raise','propogate']:
         raise Exception(f"nan_policy must be one of ['omit','raise','propogate'], but found {nan_policy}")
@@ -40,9 +63,39 @@ def shadederrorplot(x, y, ax=None, err_method='stderr', plt_args={}, shade_args=
             raise ValueError('Found nan in input')
     if ax is None:
         ax = plt.gca()
-    if 'alpha' not in shade_args:
-        shade_args['alpha'] = 0.5
+    
+    if color is not None:
+        plt_args['color'] = color
 
+    shade_args['alpha'] = alpha
+    
+    fmt = ''
+    x = None
+    y = None
+    if len(args) == 0:
+        raise ValueError('No data provided to plot.')
+    elif len(args) == 1:
+        y = args[0]
+    elif len(args) == 2:
+        if isinstance(args[1], str):
+            y, fmt = args
+        else:
+            x, y = args
+    elif len(args) == 3:
+        x, y, fmt = args
+    else:
+        raise ValueError(f'Too many args passed. Expected at most 3 (x, y, fmt)')
+    
+    if not isinstance(y, np.ndarray):
+        raise TypeError(f'y must be of type np.ndarray but got {type(y)}')
+    if not isinstance(fmt, str):
+        raise TypeError(f'fmt must be of type string but got {type(fmt)}')
+    if x is None:
+        x = np.arange(len(y))
+    
+    if y.ndim == 1:
+        y = y[:,np.newaxis]
+            
     allowed_errors = ['stderr','std']
     if err_method not in allowed_errors:
         raise ValueError(f'err_method must be one of {allowed_errors}, but found {err_method}')
@@ -59,7 +112,14 @@ def shadederrorplot(x, y, ax=None, err_method='stderr', plt_args={}, shade_args=
         elif err_method == 'std':
             y_err = y.std(1)
         
-    ax.plot(x, y_mean, **plt_args)
+    
+    if fmt == '':
+        line_, = ax.plot(x, y_mean, **plt_args)
+    else:
+        line_, = ax.plot(x, y_mean, fmt, **plt_args)
+                     
+    color = line_.get_color()
+    shade_args['color'] = color
     ax.fill_between(x, y_mean-y_err, y_mean+y_err, **shade_args)
     
 

--- a/naplib/visualization/plots.py
+++ b/naplib/visualization/plots.py
@@ -56,13 +56,6 @@ def shadederrorplot(*args, ax=None, err_method='stderr', color=None, alpha=0.4, 
     ValueError
         if nan found in input and ``nan_policy`` is 'raise'.
     '''
-    if nan_policy not in ['omit','raise','propogate']:
-        raise Exception(f"nan_policy must be one of ['omit','raise','propogate'], but found {nan_policy}")
-    if nan_policy == 'raise':
-        if np.any(np.isnan(x)) or np.any(np.isnan(y)):
-            raise ValueError('Found nan in input')
-    if ax is None:
-        ax = plt.gca()
     
     if color is not None:
         plt_args['color'] = color
@@ -86,8 +79,6 @@ def shadederrorplot(*args, ax=None, err_method='stderr', color=None, alpha=0.4, 
     else:
         raise ValueError(f'Too many args passed. Expected at most 3 (x, y, fmt)')
     
-    if not isinstance(y, np.ndarray):
-        raise TypeError(f'y must be of type np.ndarray but got {type(y)}')
     if not isinstance(fmt, str):
         raise TypeError(f'fmt must be of type string but got {type(fmt)}')
     if x is None:
@@ -95,6 +86,15 @@ def shadederrorplot(*args, ax=None, err_method='stderr', color=None, alpha=0.4, 
     
     if y.ndim == 1:
         y = y[:,np.newaxis]
+
+    if nan_policy not in ['omit','raise','propogate']:
+        raise Exception(f"nan_policy must be one of ['omit','raise','propogate'], but found {nan_policy}")
+    if nan_policy == 'raise':
+        if np.any(np.isnan(x)) or np.any(np.isnan(y)):
+            raise ValueError('Found nan in input')
+
+    if ax is None:
+        ax = plt.gca()
             
     allowed_errors = ['stderr','std']
     if err_method not in allowed_errors:

--- a/tests/visualization/test_shadederrorplot.py
+++ b/tests/visualization/test_shadederrorplot.py
@@ -4,8 +4,28 @@ import matplotlib.pyplot as plt
 
 from naplib.visualization import shadederrorplot
 
+def test_errorplot_bad_fmt_type_error():
+
+    fig, ax = plt.subplots(1,1)
+
+    with pytest.raises(TypeError):
+        shadederrorplot([0,1,2,3], np.random.rand(4,2), {'fmt': 'bad'}, ax=ax, err_method='stderr')
+
+def test_errorplot_no_args_error():
+
+    with pytest.raises(ValueError):
+        shadederrorplot()
+
+def test_errorplot_too_many_args_error():
+
+    fig, ax = plt.subplots(1,1)
+
+    with pytest.raises(ValueError):
+        shadederrorplot([0,1,2,3], np.random.rand(4,2), 'r--', 'bad_arg', ax=ax, err_method='stderr')
+
+
 def test_errorplot_error_region_stderr():
-    x = np.array([0,1,2,3,4])
+    x = np.array([-1,0,1,2,3])
     y = np.arange(1, 31).reshape((5,6)).astype('float')
     y[0,2] = 9
     y[4,1] = -0.5
@@ -17,7 +37,53 @@ def test_errorplot_error_region_stderr():
     fig, ax = plt.subplots(1,1)
     shadederrorplot(x, y, ax=ax, err_method='stderr')
 
+    assert np.allclose(ax.lines[0].get_data()[0], np.array([-1,0,1,2,3]), atol=1e-10)
+    assert np.allclose(ax.lines[0].get_data()[1], y_mean, atol=1e-10)
+
+def test_errorplot_error_region_stderr_no_x_given():
+    y = np.arange(1, 31).reshape((5,6)).astype('float')
+    y[0,2] = 9
+    y[4,1] = -0.5
+    # y_std = y.std(1)
+    y_err = np.nanstd(y, axis=1) / np.sqrt(y.shape[1])
+    y_mean = y.mean(1)
+    y_region = [y_mean - y_err, y_mean+y_err]
+
+    fig, ax = plt.subplots(1,1)
+    shadederrorplot(y, ax=ax, err_method='stderr')
+
     assert np.allclose(ax.lines[0].get_data()[0], np.array([0,1,2,3,4]), atol=1e-10)
+    assert np.allclose(ax.lines[0].get_data()[1], y_mean, atol=1e-10)
+
+def test_errorplot_error_region_stderr_no_x_given_with_fmt_string():
+    y = np.arange(1, 31).reshape((5,6)).astype('float')
+    y[0,2] = 9
+    y[4,1] = -0.5
+    # y_std = y.std(1)
+    y_err = np.nanstd(y, axis=1) / np.sqrt(y.shape[1])
+    y_mean = y.mean(1)
+    y_region = [y_mean - y_err, y_mean+y_err]
+
+    fig, ax = plt.subplots(1,1)
+    shadederrorplot(y, 'r--*', ax=ax, err_method='stderr')
+
+    assert np.allclose(ax.lines[0].get_data()[0], np.array([0,1,2,3,4]), atol=1e-10)
+    assert np.allclose(ax.lines[0].get_data()[1], y_mean, atol=1e-10)
+
+def test_errorplot_error_region_stderr_with_fmt_string():
+    x = np.array([-1, 0,1,2,3])
+    y = np.arange(1, 31).reshape((5,6)).astype('float')
+    y[0,2] = 9
+    y[4,1] = -0.5
+    # y_std = y.std(1)
+    y_err = np.nanstd(y, axis=1) / np.sqrt(y.shape[1])
+    y_mean = y.mean(1)
+    y_region = [y_mean - y_err, y_mean+y_err]
+
+    fig, ax = plt.subplots(1,1)
+    shadederrorplot(x, y, 'r--*', ax=ax, err_method='stderr')
+
+    assert np.allclose(ax.lines[0].get_data()[0], np.array([-1,0,1,2,3]), atol=1e-10)
     assert np.allclose(ax.lines[0].get_data()[1], y_mean, atol=1e-10)
 
 def test_errorplot_error_region_std_withnan_omit():


### PR DESCRIPTION
<!--
Thanks for contributing a pull request to naplib-python!
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Fixes #82 

#### What does this implement/fix? Explain your changes.
Changes the shadederrplot parameters to allow the same (x,y,fmt) *args as maplotlib's Axes.plot. This means the user can do something like

```python
shadederrorplot(x, y, 'r--')
```

or not even pass x at all

```python
shadederrorplot(y, 'r--')
```

in order to quickly change colors and line styles. Also, this adds kwargs for `color` and `alpha` to control color and alpha without having to put them in plt_args and shede_args dicts, since these are commonly changed.


#### Any other comments?
Also fixes the issue where shaded region color was not the same as line color unless manually specified.
