### PR TITLE
Update responsive_ttest.py

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -28,6 +28,12 @@ Change tags (adopted from `sklearn <https://scikit-learn.org/stable/whats_new/v0
 
 - |API| : you will need to change your code to have the same effect in the future; or a feature will be removed in the future.
 
+
+Version 0.1.6 - In Development
+------------------------------
+
+- |Fix| : Fix issue where ``stats.responsive_ttest`` was not comparing the correct values against each other to find responsive electrodes.
+
 Version 0.1.5
 -------------
 

--- a/naplib/stats/responsive_ttest.py
+++ b/naplib/stats/responsive_ttest.py
@@ -136,19 +136,17 @@ def responsive_ttest(data=None, resp='resp', befaft='befaft', sfreq='dataf', alp
         before_samples.append(resp[t][:bef])
         after_samples.append(resp[t][bef:3*bef])
 
-    before_samples = np.concatenate(before_samples, axis=0)
-    after_samples = np.concatenate(after_samples, axis=0)
-
-    N_retest = 20
+    N_retest = 10
     # do the test N_retest times and average the stats
-    for _ in range(N_retest):
-        before_samples_permuted = rng.permuted(before_samples, axis=0)
-        after_samples_permuted = rng.permuted(after_samples, axis=0)
-        N_test_samples = min([before_samples_permuted.shape[0]//2, after_samples_permuted.shape[0]//2])
-        stat, pval = ttest_ind(before_samples_permuted[:N_test_samples], after_samples_permuted[:N_test_samples], axis=0,
-                               equal_var=equal_var, alternative=alternative)
-        pvals.append(pval)
-        statistics.append(stat)
+    for trial_ in range(len(before_samples)):
+        for _ in range(N_retest):
+            before_samples_permuted = rng.permuted(before_samples[trial_], axis=0)
+            after_samples_permuted = rng.permuted(after_samples[trial_], axis=0)
+            N_test_samples = min([before_samples_permuted.shape[0]//2, after_samples_permuted.shape[0]//2])
+            stat, pval = ttest_ind(before_samples_permuted[:N_test_samples], after_samples_permuted[:N_test_samples], axis=0,
+                                   equal_var=equal_var, alternative=alternative)
+            pvals.append(pval)
+            statistics.append(stat)
 
     statistics = np.array(statistics).mean(0)
     pvals = np.array(pvals).mean(0)
@@ -168,14 +166,3 @@ def responsive_ttest(data=None, resp='resp', befaft='befaft', sfreq='dataf', alp
         return data_copy, stats
 
     return resp_corrected, stats
-
-
-    
-
-
-
-
-
-
-
-

--- a/tests/stats/test_responsive_elecs.py
+++ b/tests/stats/test_responsive_elecs.py
@@ -22,7 +22,7 @@ def test_responsive_ttest_picks_correct_electrode_from_outstruct(outstruct):
     new_out, stats = responsive_ttest(data=outstruct, resp='resp', sfreq='dataf', befaft='befaft', random_state=2)
     assert new_out[0]['resp'].shape[1] == 1
     assert np.array_equal(stats['significant'], np.array([0,1,0,0]).astype('bool'))
-    assert np.allclose(stats['stat'], np.array([ -0.14351689, -43.20687375, 0.08349735, -0.96249784]), atol=1e-7)
+    assert np.allclose(stats['stat'], np.array([-0.14351689, -43.20687375, 0.08349735, -0.96249784]), atol=1e-7)
 
 def test_responsive_ttest_picks_correct_electrode_pass_args_individually_vs_outstruct_same(outstruct):
     new_resp, stats_resp = responsive_ttest(resp=outstruct['resp'], sfreq=100, befaft=np.array([1.,1.]), random_state=2)

--- a/tests/stats/test_responsive_elecs.py
+++ b/tests/stats/test_responsive_elecs.py
@@ -22,7 +22,7 @@ def test_responsive_ttest_picks_correct_electrode_from_outstruct(outstruct):
     new_out, stats = responsive_ttest(data=outstruct, resp='resp', sfreq='dataf', befaft='befaft', random_state=2)
     assert new_out[0]['resp'].shape[1] == 1
     assert np.array_equal(stats['significant'], np.array([0,1,0,0]).astype('bool'))
-    assert np.allclose(stats['stat'], np.array([-0.14351689, -43.20687375, 0.08349735, -0.96249784]), atol=1e-7)
+    assert np.allclose(stats['stat'], np.array([-1.99077875e-01, -1.22257864e+02,  2.28465708e-02, -7.53923534e-01]), atol=1e-7)
 
 def test_responsive_ttest_picks_correct_electrode_pass_args_individually_vs_outstruct_same(outstruct):
     new_resp, stats_resp = responsive_ttest(resp=outstruct['resp'], sfreq=100, befaft=np.array([1.,1.]), random_state=2)


### PR DESCRIPTION
<!--
Thanks for contributing a pull request to naplib-python!
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.
Fix bug where responsive ttest was using data from multiple trials instead of performing ttest within each trial separately and then averaging.

#### Any other comments?
