### PR TITLE
responsive ttest change befaft param

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -28,9 +28,13 @@ Change tags (adopted from `sklearn <https://scikit-learn.org/stable/whats_new/v0
 
 - |API| : you will need to change your code to have the same effect in the future; or a feature will be removed in the future.
 
+Version 0.1.7
+-------------
 
-Version 0.1.6 - In Development
-------------------------------
+- |Fix| : Fix issue where ``stats.responsive_ttest`` to allow customization of the time periods to compare between before and after stimulus onset to test for stimulus responsiveness. Also fix a minor issue where p-values where not properly corrected for multiple tests.
+
+Version 0.1.6
+-------------
 
 - |Fix| : Fix issue where ``stats.responsive_ttest`` was not comparing the correct values against each other to find responsive electrodes.
 

--- a/docs/install.rst
+++ b/docs/install.rst
@@ -58,4 +58,4 @@ Required Dependencies
 - pyyaml
 - TextGrid
 - h5py
-
+- patsy

--- a/naplib/__init__.py
+++ b/naplib/__init__.py
@@ -10,4 +10,4 @@ import naplib.model_selection
 import naplib.utils
 from .data import Data, join_fields, concat
 
-__version__ = "0.1.6"
+__version__ = "0.1.7"

--- a/naplib/preprocessing/preprocess.py
+++ b/naplib/preprocessing/preprocess.py
@@ -11,8 +11,9 @@ def normalize(data=None, field='resp', axis=0, method='zscore'):
     Parameters
     ----------
     data : naplib.Data object, optional
-        Data object containing data to be normalized in one of the field. If not given, must give
-        the data to be normalized directly as the ``data`` argument. 
+        Data object containing data to be normalized in one of the field. If not given, then the
+        the data to be normalized must be passed directly as a list of trial arrays
+        to the ``field`` argument instead of a string. 
 
     field : string | list of np.ndarrays or a multidimensional np.ndarray
         Field to normalize. If a string, it must specify one of the fields of the Data

--- a/tests/stats/test_responsive_elecs.py
+++ b/tests/stats/test_responsive_elecs.py
@@ -22,7 +22,7 @@ def test_responsive_ttest_picks_correct_electrode_from_outstruct(outstruct):
     new_out, stats = responsive_ttest(data=outstruct, resp='resp', sfreq='dataf', befaft='befaft', random_state=2)
     assert new_out[0]['resp'].shape[1] == 1
     assert np.array_equal(stats['significant'], np.array([0,1,0,0]).astype('bool'))
-    assert np.allclose(stats['stat'], np.array([-1.99077875e-01, -1.22257864e+02,  2.28465708e-02, -7.53923534e-01]), atol=1e-7)
+    assert np.allclose(stats['stat'], np.array([-9.18367893e-01, -1.50768755e+02,  8.01840241e-02, -1.10738582e+00]), atol=1e-7)
 
 def test_responsive_ttest_picks_correct_electrode_pass_args_individually_vs_outstruct_same(outstruct):
     new_resp, stats_resp = responsive_ttest(resp=outstruct['resp'], sfreq=100, befaft=np.array([1.,1.]), random_state=2)


### PR DESCRIPTION
<!--
Thanks for contributing a pull request to naplib-python!
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.
Changes the use of befaft in the responsive ttest to allow for editing the after-onset period which is compared to the before onset period. Previously, it was hard-coded that the period of length N before the sound onset would be compared to the period of length 2N immediately following the sound onset. Now, that can be specified by passing 
```python
befaft=np.array([N, M])
```
to compare the first N seconds of each trial to the following M seconds of each trial.

#### Any other comments?
Also fixed an issue where the uncorrected pvalues were being returned.

Also Fixes #85 
