### PR TITLE
Shadederrorplot median and percentile bounds

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -29,6 +29,11 @@ Change tags (adopted from `sklearn <https://scikit-learn.org/stable/whats_new/v0
 - |API| : you will need to change your code to have the same effect in the future; or a feature will be removed in the future.
 
 
+Version 0.1.9 - In Development
+------------------------------
+
+- |Enhancement| : Expanded the functionality of ``naplib.visualization.shadederrorplot`` to allow computing the confidence interval using percentiles (such as 95% confidence interval), and to allow plotting the median or the mean at each time point.
+
 Version 0.1.8
 -------------
 

--- a/naplib/__init__.py
+++ b/naplib/__init__.py
@@ -10,4 +10,4 @@ import naplib.model_selection
 import naplib.utils
 from .data import Data, join_fields, concat
 
-__version__ = "0.1.8"
+__version__ = "0.1.9"

--- a/naplib/visualization/plots.py
+++ b/naplib/visualization/plots.py
@@ -8,6 +8,9 @@ from scipy import signal as sig
 
 def shadederrorplot(*args, ax=None, reduction='mean', err_method='stderr', color=None, alpha=0.4, plt_args={}, shade_args={}, nan_policy='omit'):
     '''
+    Plot the average/median value at each time point and a shaded region indicating error or confidence
+    level above and below the line.
+
     Parameters
     ----------
     x : array-like, shape (n_samples,), optional

--- a/naplib/visualization/plots.py
+++ b/naplib/visualization/plots.py
@@ -32,7 +32,6 @@ def shadederrorplot(*args, ax=None, reduction='mean', err_method='stderr', color
         a 95% confidence interval around the mean (i.e. the interval from the 2.5th percentile
         to the 97.5th percentile). Note, if the data have significant outliers and reduction='mean'
         then the confidence interval bounds might not surround the mean value line.
-        Also, nan values are not omitted if specifying a confidence interval.
     ax : plt.Axes instance, optional
         Axes to use. If not specified, will use current axes.
     color : str, default=None
@@ -133,7 +132,7 @@ def shadederrorplot(*args, ax=None, reduction='mean', err_method='stderr', color
             y_err = np.nanstd(y, axis=1)
         else:
             alpha_level = 1.0 - err_method
-            y_err = [np.percentile(y, 100*alpha_level/2., axis=1), np.percentile(y, 100*(1-(alpha_level/2.)), axis=1)]
+            y_err = [np.nanpercentile(y, 100*alpha_level/2., axis=1), np.nanpercentile(y, 100*(1-(alpha_level/2.)), axis=1)]
     else: # propogate, since 'raise' has already been taken care of
         y_mean = reduction_func(y, axis=1)
         if err_method == 'stderr':

--- a/naplib/visualization/plots.py
+++ b/naplib/visualization/plots.py
@@ -27,6 +27,8 @@ def shadederrorplot(*args, ax=None, reduction='mean', err_method='stderr', color
         basic line properties. All of these and more can also be
         controlled by keyword arguments within color or plt_args.
         This argument cannot be passed as keyword.
+    ax : plt.Axes instance, optional
+        Axes to use. If not specified, will use current axes.
     reduction : str, default='mean'
         Reduction method, either 'mean' or 'median'.
     err_method : string or float, default='stderr'
@@ -35,8 +37,6 @@ def shadederrorplot(*args, ax=None, reduction='mean', err_method='stderr', color
         a 95% confidence interval around the mean (i.e. the interval from the 2.5th percentile
         to the 97.5th percentile). Note, if the data have significant outliers and reduction='mean'
         then the confidence interval bounds might not surround the mean value line.
-    ax : plt.Axes instance, optional
-        Axes to use. If not specified, will use current axes.
     color : str, default=None
         Color to plot line and shaded region. Defaults to next color in color cycle.
     alpha : float, default=0.4

--- a/tests/visualization/test_shadederrorplot.py
+++ b/tests/visualization/test_shadederrorplot.py
@@ -39,6 +39,14 @@ def test_errorplot_bad_err_method():
         shadederrorplot([0,1,2,3], np.random.rand(4,2), ax=ax, err_method=1.2)
     assert 'is a float then it must be in the range (0, 1]' in str(err)
 
+def test_errorplot_bad_reduction():
+
+    fig, ax = plt.subplots(1,1)
+
+    with pytest.raises(ValueError) as err:
+        shadederrorplot([0,1,2,3], np.random.rand(4,2), ax=ax, reduction='bad')
+    assert 'reduction must be either' in str(err)
+
 def test_errorplot_error_region_median():
     x = np.array([-1,0,1,2,3])
     y = np.arange(1, 31).reshape((5,6)).astype('float')

--- a/tests/visualization/test_shadederrorplot.py
+++ b/tests/visualization/test_shadederrorplot.py
@@ -41,7 +41,7 @@ def test_errorplot_bad_err_method():
 
     with pytest.raises(ValueError) as err:
         shadederrorplot([0,1,2,3], np.random.rand(4,2), ax=ax, err_method={})
-    assert 'must be either a string or a float' in str(err)
+    assert ' must be either a string or a float' in str(err)
 
 def test_errorplot_bad_reduction():
 

--- a/tests/visualization/test_shadederrorplot.py
+++ b/tests/visualization/test_shadederrorplot.py
@@ -72,6 +72,42 @@ def test_errorplot_error_region_median_propogate():
     assert np.allclose(ax.lines[0].get_data()[0], np.array([-1,0,1,2,3]), atol=1e-10)
     assert np.allclose(ax.lines[0].get_data()[1][~nan_mask], y_mean[~nan_mask], atol=1e-10)
 
+def test_errorplot_error_region_percentile_propogate():
+    x = np.array([-1,0,1,2,3])
+    y = np.arange(1, 31).reshape((5,6)).astype('float')
+    y[0,2] = 9
+    y[4,1] = -0.5
+    y[2,0] = np.nan
+    # y_std = y.std(1)
+    y_err1 = np.percentile(y, 2.5, axis=1)
+    y_err2 = np.percentile(y, 97.5, axis=1)
+    y_mean = y.mean(1)
+    y_region = [y_err1, y_err2]
+
+    fig, ax = plt.subplots(1,1)
+    shadederrorplot(x, y, ax=ax, err_method=0.95, nan_policy='propogate')
+    nan_mask = np.isnan(y_mean)
+    assert np.allclose(ax.lines[0].get_data()[0], np.array([-1,0,1,2,3]), atol=1e-10)
+    assert np.allclose(ax.lines[0].get_data()[1][~nan_mask], y_mean[~nan_mask], atol=1e-10)
+
+def test_errorplot_error_region_percentile_omit():
+    x = np.array([-1,0,1,2,3])
+    y = np.arange(1, 31).reshape((5,6)).astype('float')
+    y[0,2] = 9
+    y[4,1] = -0.5
+    y[2,0] = np.nan
+    # y_std = y.std(1)
+    y_err1 = np.nanpercentile(y, 2.5, axis=1)
+    y_err2 = np.nanpercentile(y, 97.5, axis=1)
+    y_mean = np.nanmean(y, axis=1)
+    y_region = [y_err1, y_err2]
+
+    fig, ax = plt.subplots(1,1)
+    shadederrorplot(x, y, ax=ax, err_method=0.95, nan_policy='omit')
+    nan_mask = np.isnan(y_mean)
+    assert np.allclose(ax.lines[0].get_data()[0], np.array([-1,0,1,2,3]), atol=1e-10)
+    assert np.allclose(ax.lines[0].get_data()[1], y_mean, atol=1e-10)
+
 def test_errorplot_error_region_stderr():
     x = np.array([-1,0,1,2,3])
     y = np.arange(1, 31).reshape((5,6)).astype('float')

--- a/tests/visualization/test_shadederrorplot.py
+++ b/tests/visualization/test_shadederrorplot.py
@@ -39,6 +39,10 @@ def test_errorplot_bad_err_method():
         shadederrorplot([0,1,2,3], np.random.rand(4,2), ax=ax, err_method=1.2)
     assert 'is a float then it must be in the range (0, 1]' in str(err)
 
+    with pytest.raises(ValueError) as err:
+        shadederrorplot([0,1,2,3], np.random.rand(4,2), ax=ax, err_method={})
+    assert 'must be either a string or a float' in str(err)
+
 def test_errorplot_bad_reduction():
 
     fig, ax = plt.subplots(1,1)

--- a/tests/visualization/test_shadederrorplot.py
+++ b/tests/visualization/test_shadederrorplot.py
@@ -23,6 +23,54 @@ def test_errorplot_too_many_args_error():
     with pytest.raises(ValueError):
         shadederrorplot([0,1,2,3], np.random.rand(4,2), 'r--', 'bad_arg', ax=ax, err_method='stderr')
 
+def test_errorplot_bad_err_method():
+
+    fig, ax = plt.subplots(1,1)
+
+    with pytest.raises(ValueError) as err:
+        shadederrorplot([0,1,2,3], np.random.rand(4,2), ax=ax, err_method='not an option')
+    assert 'is a string but is not one of' in str(err)
+
+    with pytest.raises(ValueError) as err:
+        shadederrorplot([0,1,2,3], np.random.rand(4,2), ax=ax, err_method=-0.1)
+    assert 'is a float then it must be in the range (0, 1]' in str(err)
+
+    with pytest.raises(ValueError) as err:
+        shadederrorplot([0,1,2,3], np.random.rand(4,2), ax=ax, err_method=1.2)
+    assert 'is a float then it must be in the range (0, 1]' in str(err)
+
+def test_errorplot_error_region_median():
+    x = np.array([-1,0,1,2,3])
+    y = np.arange(1, 31).reshape((5,6)).astype('float')
+    y[0,2] = 9
+    y[4,1] = -0.5
+    # y_std = y.std(1)
+    y_err = np.nanstd(y, axis=1) / np.sqrt(y.shape[1])
+    y_mean = np.median(y, axis=1)
+    y_region = [y_mean - y_err, y_mean+y_err]
+
+    fig, ax = plt.subplots(1,1)
+    shadederrorplot(x, y, reduction='median', ax=ax, err_method='stderr')
+
+    assert np.allclose(ax.lines[0].get_data()[0], np.array([-1,0,1,2,3]), atol=1e-10)
+    assert np.allclose(ax.lines[0].get_data()[1], y_mean, atol=1e-10)
+
+def test_errorplot_error_region_median_propogate():
+    x = np.array([-1,0,1,2,3])
+    y = np.arange(1, 31).reshape((5,6)).astype('float')
+    y[0,2] = 9
+    y[4,1] = -0.5
+    y[2,0] = np.nan
+    # y_std = y.std(1)
+    y_err = np.std(y, axis=1) / np.sqrt(y.shape[1])
+    y_mean = np.median(y, axis=1)
+    y_region = [y_mean - y_err, y_mean+y_err]
+
+    fig, ax = plt.subplots(1,1)
+    shadederrorplot(x, y, reduction='median', ax=ax, err_method='stderr', nan_policy='propogate')
+    nan_mask = np.isnan(y_mean)
+    assert np.allclose(ax.lines[0].get_data()[0], np.array([-1,0,1,2,3]), atol=1e-10)
+    assert np.allclose(ax.lines[0].get_data()[1][~nan_mask], y_mean[~nan_mask], atol=1e-10)
 
 def test_errorplot_error_region_stderr():
     x = np.array([-1,0,1,2,3])
@@ -39,6 +87,23 @@ def test_errorplot_error_region_stderr():
 
     assert np.allclose(ax.lines[0].get_data()[0], np.array([-1,0,1,2,3]), atol=1e-10)
     assert np.allclose(ax.lines[0].get_data()[1], y_mean, atol=1e-10)
+
+def test_errorplot_error_region_percentile_no_x_given():
+    y = np.arange(1, 31).reshape((5,6)).astype('float')
+    y[0,2] = 9
+    y[4,1] = -0.5
+    # y_std = y.std(1)
+    y_err1 = np.percentile(y, 2.5, axis=1)
+    y_err2 = np.percentile(y, 97.5, axis=1)
+    y_mean = y.mean(1)
+    y_region = [y_err1, y_err2]
+
+    fig, ax = plt.subplots(1,1)
+    shadederrorplot(y, ax=ax, err_method=0.95)
+
+    assert np.allclose(ax.lines[0].get_data()[0], np.array([0,1,2,3,4]), atol=1e-10)
+    assert np.allclose(ax.lines[0].get_data()[1], y_mean, atol=1e-10)
+
 
 def test_errorplot_error_region_stderr_no_x_given():
     y = np.arange(1, 31).reshape((5,6)).astype('float')
@@ -122,5 +187,7 @@ def test_errorplot_error_region_std_withnan_raise():
     y_mean = np.nanmean(y,1)
 
     fig, ax = plt.subplots(1,1)
-    with pytest.raises(ValueError):
+    with pytest.raises(ValueError) as err:
         shadederrorplot(x, y, ax=ax, err_method='std', nan_policy='raise')
+    assert 'Found nan in input' in str(err)
+


### PR DESCRIPTION
<!--
Thanks for contributing a pull request to naplib-python!
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.
Adds 2 main features to ``shadederrorplot``

1) add a `reduction` kwarg which can be 'mean' or 'median'
2) allow `err_method` to be a float between 0 and 1 and thus create a confidence interval based on percentile range
