### PR TITLE
Improvements to robustness

### DIFF
--- a/naplib/io/load_edf.py
+++ b/naplib/io/load_edf.py
@@ -41,6 +41,9 @@ def load_edf(path: str, t1: float=0, t2: float=0) -> Dict:
         header_size = int(fin.read(8).decode('ascii'))
         _ = fin.seek(44, 1)
 
+        if version != 0:
+            raise NotImplementedError('EDF version > 0 not yet supported.')
+
         num_records = int(fin.read(8).decode('ascii'))
         record_dur = float(fin.read(8).decode('ascii'))
         num_signals = int(fin.read(4).decode('ascii'))

--- a/naplib/io/load_edf.py
+++ b/naplib/io/load_edf.py
@@ -8,28 +8,26 @@ from typing import Iterable, Dict
 
 def load_edf(path: str, t1: float=0, t2: float=0) -> Dict:
     """
-    Load data from TDT structure. Directory should contain a .tdt file.
+    Load data from EDF structure. Path should be a .edf file.
 
     TODO: This function supports the original EDF format. For the EDF+ format
-    we might want to use the PyEDFlib library. It is ~15x slower.
+    we might want to use the PyEDFlib or mne libraries. They are slower.
     
     Parameters
     ----------
-    directory : str, path-like
-        Directory containing TDT data files (tev, sev, and/or tin files, etc.)
+    path : str, path-like
+        Path to EDF data file (*.edf)
     t1 : float, default=0
         Starting time to extract
     t2 : float, default=0
         Ending time to extract until (default of 0 extracts until end of file)
-    wav_stream : str, default='Wav5'
-        The name of the stream containing the audio recording to extract.
     
     Returns
     -------
     loaded_dict : dict from string to numpy array or float
         Keys: 'data' - loaded neural recording (time*channels), 'data_f' - sampling rate of data,
         'wav' - loaded audio recording (time*channels), wav_f' - sampling rate of sound,
-        'labels' - array of labels for the channel streams
+        'labels' - array of labels for electrodes, 'wav_labels' - array of labels for auxiliary channels
     """
 
     with open(path, 'rb') as fin:

--- a/naplib/naplab/alignment.py
+++ b/naplib/naplab/alignment.py
@@ -43,6 +43,8 @@ def align_stimulus_to_recording(rec_audio, rec_fs, stim_dict, stim_order,
         Pearson's correlation between the stimulus and recorded audio for each trial
     '''
 
+    # Z-score the recorded audio to discard DC offset
+    rec_audio = stats.zscore(rec_audio, axis=0)
 
     # Optionally, derive analytic envelope of the recorded audio
     if use_hilbert:
@@ -94,15 +96,15 @@ def align_stimulus_to_recording(rec_audio, rec_fs, stim_dict, stim_order,
 
             # Search recorded audio until correlation confidence threshold is met
             FOUND = False
-            while not FOUND:
+            while not FOUND and n_start_look + len(stim) <= len(rec_audio):
+                # Number of samples of recorded audio to search over
+                n_search_use = min(n_search + len(stim), len(rec_audio) - n_start_look)
 
                 # Get segment of recorded audio to search
-                rec_audio_use = rec_audio[n_start_look : n_start_look + n_search]
+                rec_audio_use = rec_audio[n_start_look : n_start_look + n_search_use]
 
                 # Perform cross correlation
-                corrs = sig.correlate(rec_audio_use, stim, mode='full')
-                # Remove segment where stim is correlated with zeros (instead of recorded audio)
-                corrs = np.abs(corrs[len(stim)-1:])
+                corrs = sig.correlate(rec_audio_use, stim, mode='valid')
 
                 # Find points of cross correlation to search
                 corr_peaks = sig.find_peaks(corrs, height=np.percentile(corrs, 99.9))[0]
@@ -133,11 +135,19 @@ def align_stimulus_to_recording(rec_audio, rec_fs, stim_dict, stim_order,
                     max_corrs.append(max_val)
 
                     if verbose:
-                        print(f'Found {stim_name}', possible_times)
-                else:
-                    # Jump ahead by 1/10th of the search time
-                    n_start_look = n_start_look + n_search//10
+                        print(f'Found {stim_name} with correlation={max_val:.4f} @', possible_times)
 
+                    # Jump ahead to 99th percentile of the found stimulus
+                    n_start_look = n_start_look + max_ind + len(stim)*99//100
+                else:
+                    # Jump ahead to 99th percentile of last search window
+                    n_start_look = n_start_look + n_search*99//100
+
+            if not FOUND:
+                plt.figure()
+                plt.plot(rec_audio)
+                plt.show()
+                raise ValueError('Failed to find all stimuli during alignment. Is this the correct audio channel?')
 
         # Determine which stimulus channel was best, set useCh, save inds
         if useCh == None and verbose:


### PR DESCRIPTION
<!--
Thanks for contributing a pull request to naplib-python!
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.

Fixes #116.

This PR targets improving robustness of the alignment functionality:
* Two new methods for inferring which recording channels to use for alignment: 'interactive' and 'crosscorr'.
* Recorded channel used for alignment is now z-scored at the beginning of alignment to discard DC offset.
* Alignment search window is now always larger than the stimulus duration to allow for maximal robustness when stimuli are long.

#### Any other comments?

There are also some minor refactors, docstring and bug fixes.