### PR TITLE
load wav as float with rescale

### DIFF
--- a/naplib/features/auditory_spectrogram.py
+++ b/naplib/features/auditory_spectrogram.py
@@ -72,6 +72,8 @@ def auditory_spectrogram(x, sfreq, frame_len=8, tc=4, factor='linear'):
     -----
     This is a python re-implementation of the Matlab function `wav2aud` in the
     `NSLtools toolbox <https://github.com/tel/NSLtools>`_.
+
+    For correct performance, x should be a float array.
     
     References
     ----------

--- a/naplib/io/load_wav_dir.py
+++ b/naplib/io/load_wav_dir.py
@@ -45,6 +45,6 @@ def load_wav_dir(directory: str, pattern: Optional[str]=None, rescale=False) -> 
                 loaded_dict[wav_name] = (fs, data / -np.float32(dtype_info.min))
             elif  data.dtype in [np.uint8]:
                 dtype_info = np.iinfo(data.dtype)
-                loaded_dict[wav_name] = (fs, (data / 128.0 - 1.0).astype(np.float32)) # map between -1 and 1
+                loaded_dict[wav_name] = (fs, (data / np.float32(128.0)) - 1) # map between -1 and 1
     
     return loaded_dict

--- a/naplib/io/load_wav_dir.py
+++ b/naplib/io/load_wav_dir.py
@@ -42,7 +42,7 @@ def load_wav_dir(directory: str, pattern: Optional[str]=None, rescale=False) -> 
             # check dtype and only
             if data.dtype in [np.int16, np.int32]:
                 dtype_info = np.iinfo(data.dtype)
-                loaded_dict[wav_name] = (fs, data / np.float32(dtype_info.min))
+                loaded_dict[wav_name] = (fs, data / -np.float32(dtype_info.min))
             elif  data.dtype in [np.uint8]:
                 dtype_info = np.iinfo(data.dtype)
                 loaded_dict[wav_name] = (fs, data / np.float32(dtype_info.max))

--- a/naplib/io/load_wav_dir.py
+++ b/naplib/io/load_wav_dir.py
@@ -4,7 +4,7 @@ import numpy as np
 from typing import Dict, Optional, Tuple
 from scipy.io import wavfile
 
-def load_wav_dir(directory: str, pattern: Optional[str]=None, rescale=False) -> Dict[str, Tuple[float, np.ndarray]]:
+def load_wav_dir(directory: str, pattern: Optional[str]=None, rescale=True) -> Dict[str, Tuple[float, np.ndarray]]:
     """
     Load a set of wav files in a directory and return then in a dict mapping
     from filename (without the .wav suffix) to tuples of floats and numpy arrays
@@ -19,11 +19,12 @@ def load_wav_dir(directory: str, pattern: Optional[str]=None, rescale=False) -> 
         If provided, should be a regex pattern which will be used to match against
         the wav files found in the directory. For example, if ``pattern=r".*_stim.*",
         then only the wav files whose base name contains "_stim" will be loaded.
-    rescale : bool, default=False
+    rescale : bool, default=True
         If True, convert each input to a float in the range -1 to 1 based on the
         max value of the loaded dtype. For example, a wav file stored as 16-bit
         integers will be rescaled to np.float32 between -1 and 1 by dividing by
-        32768.0. This is only done on wav files that are integer types.
+        32768.0. This is only done on wav files that are integer types. If True,
+        output is always of type np.float32
     
     Returns
     -------
@@ -46,5 +47,7 @@ def load_wav_dir(directory: str, pattern: Optional[str]=None, rescale=False) -> 
             elif  data.dtype in [np.uint8]:
                 dtype_info = np.iinfo(data.dtype)
                 loaded_dict[wav_name] = (fs, ((data / np.float32(128.0)) - 1).astype(np.float32)) # map between -1 and 1
+            else:
+                loaded_dict[wav_name] = (fs, data.astype(np.float32))
     
     return loaded_dict

--- a/naplib/io/load_wav_dir.py
+++ b/naplib/io/load_wav_dir.py
@@ -45,6 +45,6 @@ def load_wav_dir(directory: str, pattern: Optional[str]=None, rescale=False) -> 
                 loaded_dict[wav_name] = (fs, data / -np.float32(dtype_info.min))
             elif  data.dtype in [np.uint8]:
                 dtype_info = np.iinfo(data.dtype)
-                loaded_dict[wav_name] = (fs, data / np.float32(dtype_info.max))
+                loaded_dict[wav_name] = (fs, data / 128.0 - 1.0) # map between -1 and 1
     
     return loaded_dict

--- a/naplib/io/load_wav_dir.py
+++ b/naplib/io/load_wav_dir.py
@@ -42,9 +42,9 @@ def load_wav_dir(directory: str, pattern: Optional[str]=None, rescale=False) -> 
             # check dtype and only
             if data.dtype in [np.int16, np.int32]:
                 dtype_info = np.iinfo(data.dtype)
-                loaded_dict[wav_name] = (fs, data / -np.float32(dtype_info.min))
+                loaded_dict[wav_name] = (fs, (data / -np.float32(dtype_info.min)).astype(np.float32))
             elif  data.dtype in [np.uint8]:
                 dtype_info = np.iinfo(data.dtype)
-                loaded_dict[wav_name] = (fs, (data / np.float32(128.0)) - 1) # map between -1 and 1
+                loaded_dict[wav_name] = (fs, ((data / np.float32(128.0)) - 1).astype(np.float32)) # map between -1 and 1
     
     return loaded_dict

--- a/naplib/io/load_wav_dir.py
+++ b/naplib/io/load_wav_dir.py
@@ -40,7 +40,7 @@ def load_wav_dir(directory: str, pattern: Optional[str]=None, rescale=False) -> 
         loaded_dict[wav_name] = (fs, data) # separated the tuple when reading file and inputting here for code-readability
         if rescale:
             # check dtype and only
-            if data.dtype in [np.float32, np.float64]:
+            if data.dtype in [np.int16, np.int32]:
                 dtype_info = np.iinfo(data.dtype)
                 loaded_dict[wav_name] = (fs, data / np.float32(dtype_info.min))
             elif  data.dtype in [np.uint8]:

--- a/naplib/io/load_wav_dir.py
+++ b/naplib/io/load_wav_dir.py
@@ -45,6 +45,6 @@ def load_wav_dir(directory: str, pattern: Optional[str]=None, rescale=False) -> 
                 loaded_dict[wav_name] = (fs, data / -np.float32(dtype_info.min))
             elif  data.dtype in [np.uint8]:
                 dtype_info = np.iinfo(data.dtype)
-                loaded_dict[wav_name] = (fs, data / 128.0 - 1.0) # map between -1 and 1
+                loaded_dict[wav_name] = (fs, (data / 128.0 - 1.0).astype(np.float32)) # map between -1 and 1
     
     return loaded_dict

--- a/naplib/naplab/process_ieeg.py
+++ b/naplib/naplab/process_ieeg.py
@@ -187,9 +187,9 @@ def process_ieeg(
 
     # # load stimuli files
     logging.info('Loading stimuli...')
-    stim_data = load_wav_dir(alignment_dir)
+    stim_data = load_wav_dir(alignment_dir, rescale=True)
     if stim_dirs is not None:
-        extra_stim_data = {k: load_wav_dir(stim_dir2) for k, stim_dir2 in stim_dirs.items()}
+        extra_stim_data = {k: load_wav_dir(stim_dir2, rescale=True) for k, stim_dir2 in stim_dirs.items()}
         for extra_stim_data_ in extra_stim_data.values():
             if set(stim_data.keys()) != set(extra_stim_data_.keys()):
                 raise ValueError(f'Alignment dir contains different wav files from one of the stim_dirs.'


### PR DESCRIPTION
<!--
Thanks for contributing a pull request to naplib-python!
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.
Fixes issue where auditory spectrograms don't match Matlab because wav files are being read in as integers instead of floats scaled between -1 and 1.

#### Any other comments?
