### PR TITLE
Fix concat bug for axis=0

### DIFF
--- a/naplib/data.py
+++ b/naplib/data.py
@@ -449,7 +449,7 @@ def concat(data_list, axis=0, copy=True):
     
     Parameters
     ----------
-    data : sequence of Data instances
+    data : list or tuple of Data instances
         Sequence containing the different Data objects to concatenate.
     axis : int, defualt=0
         To concantate over trials (default), axis should be 0. To concatenate
@@ -494,7 +494,12 @@ def concat(data_list, axis=0, copy=True):
     >>> d_concat['meta_data']
     ['meta1', 'meta2']
     '''
-
+    if not isinstance(data_list, (list, tuple)):
+        raise TypeError(f'data_list must be a list or tuple but got {type(data_list)}')
+        
+    if len(data_list) == 0:
+        raise ValueError('need at least one Data object to concatenate')
+        
     for out in data_list:
         if not isinstance(out, Data):
             raise TypeError(f'All inputs to data_list must be a Data instance but found {type(out)}')
@@ -540,7 +545,6 @@ def concat(data_list, axis=0, copy=True):
         raise ValueError(f'axis must be 0 or 1 but got {axis}')
         
     return data_merged
-
     
 def join_fields(data_list, fieldname='resp', axis=-1, return_as_data=False):
     '''

--- a/naplib/data.py
+++ b/naplib/data.py
@@ -437,7 +437,6 @@ class Data(Iterable):
 def concat(data_list, axis=0, copy=True):
     '''
     Concatenate Data objects across either trials or fields.
-
     This performs an inner join on the other dimension, meaning
     non-shared fields will be lost if concatenating over trials,
     and non-shared trials will be lost if concatenating over fields.
@@ -457,7 +456,6 @@ def concat(data_list, axis=0, copy=True):
         over fields, axis should be 1.
     copy : bool, default=True
         Whether to deep copy each Data object before concatenating.
-
     Returns
     -------
     data_merged : Data instance
@@ -495,7 +493,6 @@ def concat(data_list, axis=0, copy=True):
     [[1, 2], [3, 4, 5]]
     >>> d_concat['meta_data']
     ['meta1', 'meta2']
-
     '''
 
     for out in data_list:
@@ -506,13 +503,10 @@ def concat(data_list, axis=0, copy=True):
         return data_list[0]
     
     if axis == 0:
-        field_set = OrderedDict({k: None for k in data_list[0].fields})
+        field_set = set(data_list[0].fields)
         for data in data_list[1:]:
-            subset = set(field_set.keys()).intersection(set(data.fields))
-            for k in field_set:
-                if k not in subset:
-                    field_set.pop(k)
-        field_set = list(field_set.keys())
+            field_set = field_set.intersection(set(data.fields))
+        field_set = [ff for ff in data_list[0].fields if ff in field_set]
         
         if copy:
             data_merged = deepcopy(data_list[0][field_set])


### PR DESCRIPTION
<!--
Thanks for contributing a pull request to naplib-python!
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.
Fixes bug where if concat with axis=0 and the fields are not equivalent, raises Runtime error because OrderedDict is changed during loop.

#### Any other comments?
