### PR TITLE
Support for parallelized TRF estimation

### DIFF
--- a/examples/strf_fitting/plot_STRF_fitting_basics.py
+++ b/examples/strf_fitting/plot_STRF_fitting_basics.py
@@ -66,12 +66,8 @@ tmin = 0 # receptive field begins at time=0
 tmax = 0.3 # receptive field ends at a lag of 0.4 seconds
 sfreq = 100 # sampling frequency of data
 
-# For the sake of the cleanliness of this notebook, we set verbose=1
-# Setting verbose=2 would print lots of information
-# about the cross-validation procedure while the STRFs are being computed,
-# and verbose=0 would print nothing during fitting
-strf_model = nl.encoding.TRF(tmin, tmax, sfreq, estimator=Ridge(10), verbose=1)
-
+# setting show_progress=False would disable the progress bar
+strf_model = nl.encoding.TRF(tmin, tmax, sfreq, estimator=Ridge(10), show_progress=True)
 
 # leave out 1 trial for testing
 data_train = data[:-1]
@@ -90,7 +86,7 @@ strf_model.fit(data=data_train, X='spec_32', y='resp')
 # define the estimator to be used in this TRF model
 estimator = ElasticNet(l1_ratio=0.01)
 
-strf_model_2 = nl.encoding.TRF(tmin, tmax, sfreq, estimator=estimator, verbose=1)
+strf_model_2 = nl.encoding.TRF(tmin, tmax, sfreq, estimator=estimator)
 strf_model_2.fit(data=data_train, X='spec_32', y='resp')
 
 

--- a/naplib/encoding/trf.py
+++ b/naplib/encoding/trf.py
@@ -170,14 +170,10 @@ class TRF(BaseEstimator):
             args.append((ch, X_delayed, y_single, copy.deepcopy(self.estimator)))
 
         with Pool(self.n_jobs) as p:
-            if self.show_progress:
-                with tqdm(total=len(y_delayed)) as pbar:
-                    for ch, model in p.imap_unordered(_fit_channel, args):
-                        self.models_[ch] = model
-                        pbar.update()
-            else:
+            with tqdm(total=len(y_delayed), disable=not self.show_progress) as pbar:
                 for ch, model in p.imap_unordered(_fit_channel, args):
                     self.models_[ch] = model
+                    pbar.update()
 
         return self
     

--- a/naplib/encoding/trf.py
+++ b/naplib/encoding/trf.py
@@ -1,9 +1,9 @@
 import copy
-from contextlib import contextmanager,redirect_stderr,redirect_stdout
+from contextlib import contextmanager, redirect_stderr, redirect_stdout
 from os import devnull
+from multiprocessing import Pool
 
-import tqdm
-from tqdm.auto import tqdm as tqdm_
+from tqdm.auto import tqdm
 import numpy as np
 from sklearn.base import BaseEstimator
 from mne.decoding.receptive_field import _delay_time_series
@@ -47,12 +47,10 @@ class TRF(BaseEstimator):
         The default is sklearn.linear_model.RidgeCV() with alphas=np.logspace(-2, 5, 6),
         scoring='r2', cv=5. This trains ridge regularized regressors with built-in cross-validation
         over the regularization parameter using 5-fold cross validation.
-    verbose : int, default=1
-        Level of printing output desired.
-        0 prints nothing, 1 prints only a single tqdm progress bar for
-        the fitting over the n-outputs in .fit(), and 2 prints information about
-        cross-validation, such as the alpha value chosen and the corresponding scores,
-        during the fitting procedure for each output.
+    n_jobs : int, default=1
+        Number of parallel processes to use for fitting TRFs
+    show_progress : bool, default=True
+        Whether to show a tqdm progress bar for the fitting over the n-outputs in .fit()
 
     Attributes
     ----------
@@ -73,7 +71,8 @@ class TRF(BaseEstimator):
                  tmax,
                  sfreq,
                  estimator=None,
-                 verbose=1):
+                 n_jobs=1,
+                 show_progress=True):
         
         if tmin >= tmax:
             raise ValueError(f'tmin must be less than tmax, but got {tmin} and {tmax}')
@@ -85,7 +84,8 @@ class TRF(BaseEstimator):
             self.estimator = RidgeCV(alphas=np.logspace(-2, 5, 6), cv=5)
         else:
             self.estimator = estimator
-        self.verbose = verbose
+        self.n_jobs = n_jobs
+        self.show_progress = show_progress
         
     
     @property
@@ -108,11 +108,9 @@ class TRF(BaseEstimator):
         if not X.ndim == 2:
             raise ValueError(f'Each trial input must be 2 dimensional but got trial with shape {X.shape}')
         # X is now shape (n_times, n_feats, n_delays)
-        X = _delay_time_series(X, self.tmin, self.tmax, self.sfreq,
-                               fill_mean=False)
-        x_shape = X.shape
-        X = X.reshape(x_shape[0], -1)
-            
+        X = _delay_time_series(X, self.tmin, self.tmax, self.sfreq, fill_mean=False)
+        X = X.reshape(X.shape[0], -1)
+
         return X, y
 
     def fit(self, data=None, X='aud', y='resp'):
@@ -142,47 +140,45 @@ class TRF(BaseEstimator):
         Returns
         -------
         self : returns an instance of self
-        
         '''
         
-        X_, y_ = _parse_outstruct_args(data, copy.deepcopy(X), copy.deepcopy(y))
+        X, y = _parse_outstruct_args(data, X, y)
         
-        if y_[0].ndim == 1:
-            y_ = [yy[:,np.newaxis] for yy in y_]
+        if y[0].ndim == 1:
+            y = [yy[:,np.newaxis] for yy in y]
         
-        self.ndim_y_ = y_[0].ndim
-        
-        X_delayed, y_delayed = [], []
-        
-        self.X_feats_ = X_[0].shape[-1]
+        self.ndim_y_ = y[0].ndim
+        self.X_feats_ = X[0].shape[-1]
+        self.n_targets_ = y[0].shape[1]
+        self.y_feats_ = y[0].shape[-1] if self.ndim_y_==3 else 1
 
-        for xx, yy in zip(X_, y_):
+        X_delayed, y_delayed = [], []
+        for xx, yy in zip(X, y):
             X_tmp, y_tmp = self._delay_and_reshape(xx, yy)
             X_delayed.append(X_tmp)
             y_delayed.append(y_tmp)
         
         X_delayed = np.concatenate(X_delayed, axis=0)
         y_delayed = np.concatenate(y_delayed, axis=0)
-        
-        self.n_targets_ = y_[0].shape[1]
-        self.y_feats_ = y_[0].shape[-1] if self.ndim_y_==3 else 1
+        y_delayed = [yy.copy() for yy in y_delayed.swapaxes(0, 1)]
         
         # for each target variable, fit a TRF model
-        self.models_ = [copy.deepcopy(self.estimator) for _ in range(y_delayed.shape[1])]
+        self.models_ = [None] * len(y_delayed)
         
-        if self.verbose >= 1:
-            disable_tqdm = False
-        else:
-            disable_tqdm = True
+        args = []
+        for ch, y_single in enumerate(y_delayed):
+            args.append((ch, X_delayed, y_single, copy.deepcopy(self.estimator)))
 
-        for target_idx in tqdm_(range(y_delayed.shape[1]), disable=disable_tqdm):
-            y_thistarget = y_delayed[:,target_idx]
-            if self.verbose >= 2:
-                print(f'Fitting model for output variable {target_idx}...')
-            # if self.ndim_y_ == 2:
-            #     y_thistarget = y_thistarget[:,np.newaxis]
-            self.models_[target_idx].fit(X_delayed, y_thistarget)
-             
+        with Pool(self.n_jobs) as p:
+            if self.show_progress:
+                with tqdm(total=len(y_delayed)) as pbar:
+                    for ch, model in p.imap_unordered(_fit_channel, args):
+                        self.models_[ch] = model
+                        pbar.update()
+            else:
+                for ch, model in p.imap_unordered(_fit_channel, args):
+                    self.models_[ch] = model
+
         return self
     
     @property
@@ -358,4 +354,9 @@ class TRF(BaseEstimator):
             scores.append(np.corrcoef(y_thistarget, pred)[0,1])
         
         return np.array(scores)
-        
+
+
+def _fit_channel(args):
+    ch, X, y, model = args
+    return ch, model.fit(X, y)
+

--- a/tests/encoding/test_trf.py
+++ b/tests/encoding/test_trf.py
@@ -31,7 +31,7 @@ def test_1D_input_1D_output_trf_on_Data(data):
     assert score > 0.99
 
 def test_1D_input_1D_output_trf(data):
-    model = TRF(tmin=0, tmax=0.01, sfreq=100, estimator=data['mdl'])
+    model = TRF(tmin=0, tmax=0.01, sfreq=100, estimator=data['mdl'], show_progress=False)
     model.fit(X=data['X1'], y=data['y1'])
     assert np.allclose(data['coef'].reshape(1,1,2), model.coef_, rtol=1e-4)
 

--- a/tests/encoding/test_trf.py
+++ b/tests/encoding/test_trf.py
@@ -41,6 +41,12 @@ def test_1D_input_2D_output_trf(data):
     reshaped_coef = np.concatenate([data['coef'].reshape(1,1,2), data['coef'].reshape(1,1,2)], axis=1)
     assert np.allclose(reshaped_coef, model.coef_, rtol=1e-4)
 
+def test_1D_input_2D_output_trf_parallel(data):
+    model = TRF(tmin=0, tmax=0.01, sfreq=100, estimator=data['mdl'], n_jobs=2)
+    model.fit(X=data['X1'], y=data['y2'])
+    reshaped_coef = np.concatenate([data['coef'].reshape(1,1,2), data['coef'].reshape(1,1,2)], axis=1)
+    assert np.allclose(reshaped_coef, model.coef_, rtol=1e-4)
+
 def test_2D_input_1D_output_trf(data):
     model = TRF(tmin=0, tmax=0.01, sfreq=100, estimator=data['mdl'])
     model.fit(X=data['X2'], y=data['y1'])


### PR DESCRIPTION
<!--
Thanks for contributing a pull request to naplib-python!
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->

Fixes #103 

#### What does this implement/fix? Explain your changes.

Adds support for parallelized TRF estimation by dispatching separated processes to fit TRF for each output channel. The number of parallel processes is determined by field `n_jobs` of the `TRF` class.

#### Any other comments?

Also makes changes to logging inside the TRF fitting function to accommodate parallel progression.