### PR TITLE
Multiple `aud_fn`

### DIFF
--- a/naplib/naplab/process_ieeg.py
+++ b/naplib/naplab/process_ieeg.py
@@ -395,7 +395,7 @@ def process_ieeg(
         # mapping from name (like 'aud') to list of spectrograms
         for k, stim_data_dict in extra_stim_data.items():
             for name, fn in aud_fn.items():
-                final_output[f'{k} {name}' if name else k] = _spectrograms_from_stims(
+                final_output[f'{k} {name}' if name else k] = _transform_stims(
                     stim_data_dict, stim_order, final_fs, fn,
                 )
     
@@ -740,10 +740,10 @@ def _prep_aud_fn(aud_fn: Optional[Union[Callable, Dict]], aud_kwargs: Optional[D
     raise ValueError("aud_fn should be either None, callable, or dict")
 
 
-def _spectrograms_from_stims(stim_data_dict, stim_order, fs_out, aud_fn):
+def _transform_stims(stim_data_dict, stim_order, fs_out, aud_fn):
     """
-    Convert each stimulus in the stim_data_dict into a spectrogram, then return
-    a list of spectrograms ordered by stim_order (stimuli can repeat in stim_order).
+    Transform each stimulus in `stim_data_dict` using the provided function `aud_fn`,
+    then return a list of the resulting tensors ordered by stim_order (stimuli can repeat in stim_order).
     
     Parameters
     ----------

--- a/naplib/naplab/process_ieeg.py
+++ b/naplib/naplab/process_ieeg.py
@@ -124,12 +124,13 @@ def process_ieeg(
         If True, store all recorded wav channels that were stored by the neural recording hardware. This may include
         any other signals that were hooked up at the same time, such as EKG, triggers, etc.
     aud_fn : optional callable or dict, default=naplib.features.auditory_spectrogram
-        Function for computing spectrogram from trial stimulus sounds. If None, no spectrograms will be computed.
-        By default, `naplib.features.auditory_spectrogram` will be used. If a callable `f`, the function `f` will be
-        applied to each stimulus audio and should have signature `(x: NDArray, sr: float, **kwargs) -> NDArray`,
-        where `x` is 1-D audio signal with shape (in_samples,) and `sr` is the sampling rate of the audio. The returned
-        array (spectrogram) should have shape (n_samples, freq_bins). If a dictionary, the keys will be used in field
-        names in the output Data object, and the values should be callable.
+        Function(s) to be applied to each stimulus sound. If None, no audio transforms will be computed. By default,
+        `naplib.features.auditory_spectrogram` will be used to compute an auditory spectrogram. If a callable `f`,
+        the function `f` will be applied to each stimulus audio and should have signature
+        `(x: NDArray, sr: float, **kwargs) -> NDArray`, where `x` is 1-D audio signal with shape (in_samples,) and
+        `sr` is the sampling rate of the audio. The returned tensor should have shape (n_samples, n_features). If a
+        dictionary, the keys should be strings and will be used in field names of the output Data object, and the
+        values should be callable.
     aud_kwargs : optional dict, default=None
         Optional dictionary of extra arguments to be passed to `aud_fn`. Only used when `aud_fn` is a single callable.
         If `aud_kwargs` is not None and `aud_fn` is not a single callable, an error will be raised.

--- a/naplib/naplab/process_ieeg.py
+++ b/naplib/naplab/process_ieeg.py
@@ -46,7 +46,7 @@ def process_ieeg(
     line_noise_kwargs: dict={},
     store_sounds: bool=False,
     store_all_wav: bool=False,
-    aud_fn: Optional[Union[str, tuple[str, dict], Callable, tuple[Callable, dict], dict]]='default',
+    aud_fn: Optional[Union[str, Callable, tuple, dict]]='default',
     n_jobs: int=1,
 ):
     """
@@ -122,7 +122,7 @@ def process_ieeg(
     store_all_wav : bool, default=False
         If True, store all recorded wav channels that were stored by the neural recording hardware. This may include
         any other signals that were hooked up at the same time, such as EKG, triggers, etc.
-    aud_fn : Optional[Union[str, tuple[str, dict], Callable, tuple[Callable, dict], dict]], default='default'
+    aud_fn : Optional[Union[str, Callable, tuple, dict]], default='default'
         Function for computing spectrogram from trial stimulus sounds. If None, no spectrograms will be computed.
         If `'default'`, `naplib.features.auditory_spectrogram` will be used. If a callable `f`, the function `f`
         will be applied to each stimulus audio and should have signature `(x: NDArray, sr: float, **kwargs) -> NDArray`,

--- a/naplib/naplab/process_ieeg.py
+++ b/naplib/naplab/process_ieeg.py
@@ -733,7 +733,6 @@ def _prep_aud_fn(aud_fn: Optional[Union[Callable, Dict]], aud_kwargs: Optional[D
                 raise ValueError('aud_fn dictionary keys should be of type string')
             if not isinstance(f, Callable):
                 raise ValueError("aud_fn dictionary values should be callable")
-            aud_fn[k] = partial(f, **aud_kwargs) if aud_kwargs else f
 
         return aud_fn
 

--- a/tests/naplab/test_process_ieeg.py
+++ b/tests/naplab/test_process_ieeg.py
@@ -39,7 +39,6 @@ def test_single_stimuli_pipeline(small_data):
         final_fs=100,
         store_all_wav=True,
         store_sounds=True,
-        aud_fn='default',
         befaft=[1,1]
     )
 
@@ -91,7 +90,6 @@ def test_single_stimuli_spectrum_inference_method(small_data):
         aud_channel_infer_method='spectrum',
         store_all_wav=True,
         store_sounds=True,
-        aud_fn='default',
         befaft=[1,1]
     )
 
@@ -334,7 +332,8 @@ def test_single_stimuli_pipeline_with_custom_spectrogram(small_data_fs50):
         final_fs=100,
         store_all_wav=True,
         store_sounds=True,
-        aud_fn=(func, func_kwargs),
+        aud_fn=func,
+        aud_kwargs=func_kwargs,
         befaft=[1,1]
     )
 
@@ -372,7 +371,7 @@ def test_single_stimuli_pipeline_with_custom_spectrogram(small_data_fs50):
         final_fs=100,
         store_all_wav=True,
         store_sounds=True,
-        aud_fn={'ext': (func, func_kwargs)},
+        aud_fn={'ext': partial_func},
         befaft=[1,1]
     )
 

--- a/tests/naplab/test_process_ieeg.py
+++ b/tests/naplab/test_process_ieeg.py
@@ -2,6 +2,7 @@ import os
 import numpy as np
 import pytest
 import scipy.signal
+from functools import partial
 
 from naplib.io import load
 from naplib.naplab import process_ieeg
@@ -283,28 +284,11 @@ def test_single_stimuli_pipeline_with_custom_spectrogram(small_data_fs50):
     dir_path = small_data_fs50['path']
     true_data = small_data_fs50['data_dict']
 
-    data_out = process_ieeg(
-        dir_path,
-        dir_path,
-        stim_dirs={'aud_copy': dir_path},
-        bands=['raw', 'theta'],
-        phase_amp='both',
-        intermediate_fs=100,
-        final_fs=100,
-        store_all_wav=True,
-        store_sounds=True,
-        aud_fn=lambda x, sr, **kwargs: scipy.signal.spectrogram(x, sr, **kwargs)[2].T,
-        aud_kwargs={'nperseg': 256, 'noverlap': 96},
-        befaft=[1,1]
-    )
+    func = lambda x, sr, **kwargs: scipy.signal.spectrogram(x, sr, **kwargs)[2].T
+    func_kwargs = {'nperseg': 256, 'noverlap': 96}
+    partial_func = partial(func, **func_kwargs)
 
-    spec = data_out['aud_copy'][0]
-
-    # check custom spectrogram shape
-    assert spec.shape == (1200, 129)
-
-    # shape content of custom spectrogram
-    assert np.allclose(spec.max(0), np.array([
+    result = np.array([
         0.00000000e+00, 5.52224112e-04, 2.14351760e-03, 4.58641676e-03,
         7.59611558e-03, 1.08276187e-02, 1.39198815e-02, 1.65406112e-02,
         1.84254330e-02, 1.94061846e-02, 1.94249656e-02, 1.85327381e-02,
@@ -338,5 +322,62 @@ def test_single_stimuli_pipeline_with_custom_spectrogram(small_data_fs50):
         1.78736984e-04, 1.22661353e-04, 7.57407543e-05, 4.08680280e-05,
         1.83328120e-05, 6.22197967e-06, 1.29176203e-06, 8.31724165e-08,
         0.00000000e+00,
-    ]))
+    ])
+
+    data_out = process_ieeg(
+        dir_path,
+        dir_path,
+        stim_dirs={'aud_copy': dir_path},
+        bands=['raw', 'theta'],
+        phase_amp='both',
+        intermediate_fs=100,
+        final_fs=100,
+        store_all_wav=True,
+        store_sounds=True,
+        aud_fn=(func, func_kwargs),
+        befaft=[1,1]
+    )
+
+    # check custom spectrogram shape and content
+    spec = data_out['aud_copy'][0]
+    assert spec.shape == (1200, 129)
+    assert np.allclose(spec.max(0), result)
+
+    data_out = process_ieeg(
+        dir_path,
+        dir_path,
+        stim_dirs={'aud_copy': dir_path},
+        bands=['raw', 'theta'],
+        phase_amp='both',
+        intermediate_fs=100,
+        final_fs=100,
+        store_all_wav=True,
+        store_sounds=True,
+        aud_fn=partial_func,
+        befaft=[1,1]
+    )
+
+    # check custom spectrogram shape and content
+    spec = data_out['aud_copy'][0]
+    assert spec.shape == (1200, 129)
+    assert np.allclose(spec.max(0), result)
+
+    data_out = process_ieeg(
+        dir_path,
+        dir_path,
+        stim_dirs={'aud_copy': dir_path},
+        bands=['raw', 'theta'],
+        phase_amp='both',
+        intermediate_fs=100,
+        final_fs=100,
+        store_all_wav=True,
+        store_sounds=True,
+        aud_fn={'ext': (func, func_kwargs)},
+        befaft=[1,1]
+    )
+
+    # check custom spectrogram shape and content
+    spec = data_out['aud_copy ext'][0]
+    assert spec.shape == (1200, 129)
+    assert np.allclose(spec.max(0), result)
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request to naplib-python!
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.

Adds option to provide a dictionary of audio transformations to the `aud_fn` argument of `process_ieeg`. For example, this can be used to extract the spectrogram, pitch, and envelope of the stimulus audio simultaneously. Since the existing `aud_kwargs` argument of `process_ieeg` was not scalable to this case, its use has been limited to when `aud_fn` is a single callable.
