### PR TITLE
update responsive_ttest and tests

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -28,6 +28,10 @@ Change tags (adopted from `sklearn <https://scikit-learn.org/stable/whats_new/v0
 
 - |API| : you will need to change your code to have the same effect in the future; or a feature will be removed in the future.
 
+Version 1.1.0 (In development)
+------------------------------
+- |Enhancement| : Added a ``pre_post`` argument to ``stats.responsive_ttest`` to allow greater flexibility to how the responsiveness test is conducted. Also fixed a minor issue with how the test was being computed.
+
 Version 1.0.0
 -------------
 - |API| : Renamed ``stats.fratio`` to ``stats.discriminability`` and added Wilks' Lambda f-statistic as a method for computing disciminability.

--- a/examples/data_manipulation_preprocessing/plot_preprocessing_examples.py
+++ b/examples/data_manipulation_preprocessing/plot_preprocessing_examples.py
@@ -100,7 +100,7 @@ plt.show()
 # Perform t-test to remove electrodes that are not responsive
 # This function performs FDR correction by default, but many parameters can be changed to alter
 # the test
-data_responsive, stats = responsive_ttest(data, random_state=1)
+data_responsive, stats = responsive_ttest(data)
 print(stats.keys()) # statistics computed
 
 

--- a/examples/data_manipulation_preprocessing/plot_preprocessing_examples.py
+++ b/examples/data_manipulation_preprocessing/plot_preprocessing_examples.py
@@ -105,7 +105,8 @@ print(stats.keys()) # statistics computed
 
 
 # now there are only 8 electrodes remaining
-print(data_responsive['resp'][0].shape)
+print(data_responsive[0].shape)
+data['resp'] = data_responsive # set the responses to only be these good electrodes
 
 
 # plot some of the statistics computed
@@ -135,15 +136,15 @@ plt.show()
 # * beta (14-30Hz)
 
 # filter the responses to different bands and set them as new fields of the Data
-data_responsive['delta_resp'] = filter_butter(data_responsive, field='resp', Wn=[0.5, 4], order=5)
-data_responsive['theta_resp'] = filter_butter(data_responsive, field='resp', Wn=[4, 8], order=5)
-data_responsive['alpha_resp'] = filter_butter(data_responsive, field='resp', Wn=[8, 13], order=5)
-data_responsive['beta_resp'] = filter_butter(data_responsive, field='resp', Wn=[14, 30], order=5)
+data['delta_resp'] = filter_butter(data, field='resp', Wn=[0.5, 4], order=5)
+data['theta_resp'] = filter_butter(data, field='resp', Wn=[4, 8], order=5)
+data['alpha_resp'] = filter_butter(data, field='resp', Wn=[8, 13], order=5)
+data['beta_resp'] = filter_butter(data, field='resp', Wn=[14, 30], order=5)
 
 
 # To make sure the filter bands are correct or meet our requirements, get the filters used and plot them
 # If we are not satisfied with the filters, we can set the ``order`` parameter in the ``filter_butter`` function to increase the filter order.
-theta_resp, filters = filter_butter(data_responsive, Wn=[4, 8], return_filters=True, order=5)
+theta_resp, filters = filter_butter(data, Wn=[4, 8], return_filters=True, order=5)
 
 # plot frequency response
 fig, ax = plt.subplots()
@@ -151,7 +152,7 @@ nl.visualization.freq_response(filters[0], fs=data[0]['dataf'], ax=ax)
 plt.show()
 
 # use a higher order to get steeper cutoff region
-theta_resp_2, filters_2 = filter_butter(data_responsive, Wn=[4, 8], order=10, return_filters=True)
+theta_resp_2, filters_2 = filter_butter(data, Wn=[4, 8], order=10, return_filters=True)
 
 # plot frequency response
 fig, ax = plt.subplots()
@@ -165,23 +166,23 @@ plt.show()
 # 
 # Now that we have bandpassed responses, normalize each one (by z-scoring).
 
-data_responsive['delta_resp'] = normalize(data_responsive, field='delta_resp')
-data_responsive['theta_resp'] = normalize(data_responsive, field='theta_resp')
-data_responsive['alpha_resp'] = normalize(data_responsive, field='alpha_resp')
-data_responsive['beta_resp'] = normalize(data_responsive, field='beta_resp')
+data['delta_resp'] = normalize(data, field='delta_resp')
+data['theta_resp'] = normalize(data, field='theta_resp')
+data['alpha_resp'] = normalize(data, field='alpha_resp')
+data['beta_resp'] = normalize(data, field='beta_resp')
 
 trial = 0
 t = np.arange(0, 10*100) / data['dataf'][trial]
 
 fig, axes = plt.subplots(4,1,figsize=(12,8), sharex=True)
 
-axes[0].plot(t, data_responsive['delta_resp'][trial][:10*100])
+axes[0].plot(t, data['delta_resp'][trial][:10*100])
 axes[0].set_title('Delta')
-axes[1].plot(t, data_responsive['theta_resp'][trial][:10*100])
+axes[1].plot(t, data['theta_resp'][trial][:10*100])
 axes[1].set_title('Theta')
-axes[2].plot(t, data_responsive['alpha_resp'][trial][:10*100])
+axes[2].plot(t, data['alpha_resp'][trial][:10*100])
 axes[2].set_title('Alpha')
-axes[3].plot(t, data_responsive['beta_resp'][trial][:10*100])
+axes[3].plot(t, data['beta_resp'][trial][:10*100])
 axes[3].set_title('Beta')
 axes[3].set_xlabel('Time (s)')
 plt.tight_layout()

--- a/naplib/__init__.py
+++ b/naplib/__init__.py
@@ -44,5 +44,5 @@ import naplib.utils
 from .data import Data, join_fields, concat
 import naplib.naplab
 
-__version__ = "1.0.0"
+__version__ = "1.1.0"
 

--- a/naplib/naplab/process_ieeg.py
+++ b/naplib/naplab/process_ieeg.py
@@ -317,14 +317,15 @@ def process_ieeg(
     # # preprocessing
     
     # # common referencing
-    if rereference_grid == 'array':
-        if 'labels_data' not in raw_data:
-            raise ValueError('Implicit array-based rereferencing not allowed when electrode labels are not specified')
-        rereference_grid = make_contact_rereference_arr(raw_data['labels_data'])
-    elif rereference_grid == 'subject':
-        rereference_grid = np.ones((raw_data['data'].shape[1],) * 2, dtype=int)
-    elif isinstance(rereference_grid, str):
-        raise ValueError(f'Unknown rereference_grid mode: {rereference_grid}')
+    if isinstance(rereference_grid, str):
+        if rereference_grid == 'array':
+            if 'labels_data' not in raw_data:
+                raise ValueError('Implicit array-based rereferencing not allowed when electrode labels are not specified')
+            rereference_grid = make_contact_rereference_arr(raw_data['labels_data'])
+        elif rereference_grid == 'subject':
+            rereference_grid = np.ones((raw_data['data'].shape[1],) * 2, dtype=int)
+        else:
+            raise ValueError(f'Unknown string rereference_grid mode: {rereference_grid}')
 
     if rereference_grid is not None:
         logger.info(f'Performing common rereferencing using "{rereference_method}" method...')

--- a/naplib/naplab/process_ieeg.py
+++ b/naplib/naplab/process_ieeg.py
@@ -326,6 +326,7 @@ def process_ieeg(
     elif isinstance(rereference_grid, str):
         raise ValueError(f'Unknown string rereference_grid mode: {rereference_grid}')
 
+
     if rereference_grid is not None:
         logger.info(f'Performing common rereferencing using "{rereference_method}" method...')
         if store_reference:

--- a/naplib/naplab/process_ieeg.py
+++ b/naplib/naplab/process_ieeg.py
@@ -317,13 +317,15 @@ def process_ieeg(
     # # preprocessing
     
     # # common referencing
-    if isinstance(rereference_grid, str) and rereference_grid == 'array':
+    if not isinstance(rereference_grid, str):
+        pass
+    elif rereference_grid == 'array':
         if 'labels_data' not in raw_data:
             raise ValueError('Implicit array-based rereferencing not allowed when electrode labels are not specified')
         rereference_grid = make_contact_rereference_arr(raw_data['labels_data'])
-    elif isinstance(rereference_grid, str) and rereference_grid == 'subject':
+    elif rereference_grid == 'subject':
         rereference_grid = np.ones((raw_data['data'].shape[1],) * 2, dtype=int)
-    elif isinstance(rereference_grid, str):
+    else:
         raise ValueError(f'Unknown string rereference_grid mode: {rereference_grid}')
 
     if rereference_grid is not None:

--- a/naplib/naplab/process_ieeg.py
+++ b/naplib/naplab/process_ieeg.py
@@ -317,15 +317,14 @@ def process_ieeg(
     # # preprocessing
     
     # # common referencing
-    if isinstance(rereference_grid, str):
-        if rereference_grid == 'array':
-            if 'labels_data' not in raw_data:
-                raise ValueError('Implicit array-based rereferencing not allowed when electrode labels are not specified')
-            rereference_grid = make_contact_rereference_arr(raw_data['labels_data'])
-        elif rereference_grid == 'subject':
-            rereference_grid = np.ones((raw_data['data'].shape[1],) * 2, dtype=int)
-        else:
-            raise ValueError(f'Unknown string rereference_grid mode: {rereference_grid}')
+    if isinstance(rereference_grid, str) and rereference_grid == 'array':
+        if 'labels_data' not in raw_data:
+            raise ValueError('Implicit array-based rereferencing not allowed when electrode labels are not specified')
+        rereference_grid = make_contact_rereference_arr(raw_data['labels_data'])
+    elif isinstance(rereference_grid, str) and rereference_grid == 'subject':
+        rereference_grid = np.ones((raw_data['data'].shape[1],) * 2, dtype=int)
+    elif isinstance(rereference_grid, str):
+        raise ValueError(f'Unknown string rereference_grid mode: {rereference_grid}')
 
     if rereference_grid is not None:
         logger.info(f'Performing common rereferencing using "{rereference_method}" method...')

--- a/naplib/stats/responsive_ttest.py
+++ b/naplib/stats/responsive_ttest.py
@@ -122,7 +122,6 @@ def responsive_ttest(data=None, resp='resp', befaft='befaft', sfreq='dataf', alp
     after_samples = []
     pvals = []
     statistics = []
-    rng = np.random.default_rng(random_state)
     for t in range(len(resp)):
         bef = round(befaft[t][0] * sfreq[t])
         aft = round(befaft[t][1] * sfreq[t])

--- a/tests/stats/test_responsive_elecs.py
+++ b/tests/stats/test_responsive_elecs.py
@@ -20,21 +20,21 @@ def outstruct():
 
 def test_responsive_ttest_picks_correct_electrode_from_outstruct(outstruct):
     new_out, stats = responsive_ttest(data=outstruct, resp='resp', sfreq='dataf', befaft='befaft')
-    assert new_out[0]['resp'].shape[1] == 1
+    assert new_out[0].shape[1] == 1
     assert np.array_equal(stats['significant'], np.array([0,1,0,0]).astype('bool'))
     assert np.allclose(stats['stat'], np.array([-1.67113052, -63.20943622,   0.23296204,  -1.78460185]), atol=1e-7)
     assert np.allclose(stats['pval'], np.array([1.26958793e-001, 2.51319873e-266, 8.15870594e-001, 1.26958793e-001]), atol=1e-7)
 
 def test_responsive_ttest_picks_correct_electrode_from_outstruct_alternative_less(outstruct):
     new_out, stats = responsive_ttest(data=outstruct, resp='resp', sfreq='dataf', befaft='befaft', alternative='less')
-    assert new_out[0]['resp'].shape[1] == 1
+    assert new_out[0].shape[1] == 1
     assert np.array_equal(stats['significant'], np.array([0,1,0,0]).astype('bool'))
     assert np.allclose(stats['stat'], np.array([-1.67113052, -63.20943622,   0.23296204,  -1.78460185]), atol=1e-7)
     assert np.allclose(stats['pval'], np.array([6.34793965e-002, 1.25659937e-266, 5.92064703e-001, 6.34793965e-002]), atol=1e-7)
 
 def test_responsive_ttest_picks_correct_electrode_from_outstruct_alternative_greater(outstruct):
     new_out, stats = responsive_ttest(data=outstruct, resp='resp', sfreq='dataf', befaft='befaft', alternative='greater')
-    assert new_out[0]['resp'].shape[1] == 0
+    assert new_out[0].shape[1] == 0
     assert np.array_equal(stats['significant'], np.array([0,0,0,0]).astype('bool'))
     assert np.allclose(stats['stat'], np.array([-1.67113052, -63.20943622,   0.23296204,  -1.78460185]), atol=1e-7)
     assert np.allclose(stats['pval'], np.array([1., 1., 1., 1.]), atol=1e-7)
@@ -43,10 +43,24 @@ def test_responsive_ttest_picks_correct_electrode_pass_args_individually_vs_outs
     new_resp, stats_resp = responsive_ttest(resp=outstruct['resp'], sfreq=100, befaft=np.array([1.,1.]))
     new_out, stats_out = responsive_ttest(data=outstruct, resp='resp', sfreq='dataf', befaft='befaft')
 
-    assert np.array_equal(new_resp[0], new_out[0]['resp'])
-    assert np.array_equal(new_resp[1], new_out[1]['resp'])
-    assert np.array_equal(new_resp[2], new_out[2]['resp'])
+    assert np.array_equal(new_resp[0], new_out[0])
+    assert np.array_equal(new_resp[1], new_out[1])
+    assert np.array_equal(new_resp[2], new_out[2])
 
     assert np.array_equal(stats_resp['stat'], stats_out['stat'])
     assert np.array_equal(stats_resp['pval'], stats_out['pval'])
     assert np.array_equal(stats_resp['significant'], stats_out['significant'])
+
+def test_responsive_ttest_picks_correct_electrode_from_outstruct_pre_post(outstruct):
+    new_out, stats = responsive_ttest(data=outstruct, resp='resp', sfreq='dataf', befaft='befaft', pre_post=[0.75, 1.2])
+    assert new_out[0].shape[1] == 1
+    assert np.array_equal(stats['significant'], np.array([0,1,0,0]).astype('bool'))
+    assert np.allclose(stats['stat'], np.array([-7.81900414e-01, -6.77573819e+01,  6.65181396e-02, -1.64475842e+00]), atol=1e-7)
+    assert np.allclose(stats['pval'], np.array([5.79454041e-001, 5.71858778e-278, 9.46988121e-001, 2.01117368e-001]), atol=1e-7)
+    new_out, stats2 = responsive_ttest(data=outstruct, resp='resp', sfreq='dataf', befaft='befaft', pre_post=[-0.75, 0, 0, 1.2])
+    assert new_out[0].shape[1] == 1
+    assert np.array_equal(stats['significant'], stats2['significant'])
+    assert np.allclose(stats['stat'], stats2['stat'], atol=1e-7)
+    assert np.allclose(stats['pval'], stats2['pval'], atol=1e-7)
+    
+

--- a/tests/stats/test_responsive_elecs.py
+++ b/tests/stats/test_responsive_elecs.py
@@ -19,29 +19,29 @@ def outstruct():
     return Data(data_tmp)
 
 def test_responsive_ttest_picks_correct_electrode_from_outstruct(outstruct):
-    new_out, stats = responsive_ttest(data=outstruct, resp='resp', sfreq='dataf', befaft='befaft', random_state=2)
+    new_out, stats = responsive_ttest(data=outstruct, resp='resp', sfreq='dataf', befaft='befaft')
     assert new_out[0]['resp'].shape[1] == 1
     assert np.array_equal(stats['significant'], np.array([0,1,0,0]).astype('bool'))
     assert np.allclose(stats['stat'], np.array([-1.67113052, -63.20943622,   0.23296204,  -1.78460185]), atol=1e-7)
     assert np.allclose(stats['pval'], np.array([1.26958793e-001, 2.51319873e-266, 8.15870594e-001, 1.26958793e-001]), atol=1e-7)
 
 def test_responsive_ttest_picks_correct_electrode_from_outstruct_alternative_less(outstruct):
-    new_out, stats = responsive_ttest(data=outstruct, resp='resp', sfreq='dataf', befaft='befaft', random_state=2, alternative='less')
+    new_out, stats = responsive_ttest(data=outstruct, resp='resp', sfreq='dataf', befaft='befaft', alternative='less')
     assert new_out[0]['resp'].shape[1] == 1
     assert np.array_equal(stats['significant'], np.array([0,1,0,0]).astype('bool'))
     assert np.allclose(stats['stat'], np.array([-1.67113052, -63.20943622,   0.23296204,  -1.78460185]), atol=1e-7)
     assert np.allclose(stats['pval'], np.array([6.34793965e-002, 1.25659937e-266, 5.92064703e-001, 6.34793965e-002]), atol=1e-7)
 
 def test_responsive_ttest_picks_correct_electrode_from_outstruct_alternative_greater(outstruct):
-    new_out, stats = responsive_ttest(data=outstruct, resp='resp', sfreq='dataf', befaft='befaft', random_state=2, alternative='greater')
+    new_out, stats = responsive_ttest(data=outstruct, resp='resp', sfreq='dataf', befaft='befaft', alternative='greater')
     assert new_out[0]['resp'].shape[1] == 0
     assert np.array_equal(stats['significant'], np.array([0,0,0,0]).astype('bool'))
     assert np.allclose(stats['stat'], np.array([-1.67113052, -63.20943622,   0.23296204,  -1.78460185]), atol=1e-7)
     assert np.allclose(stats['pval'], np.array([1., 1., 1., 1.]), atol=1e-7)
 
 def test_responsive_ttest_picks_correct_electrode_pass_args_individually_vs_outstruct_same(outstruct):
-    new_resp, stats_resp = responsive_ttest(resp=outstruct['resp'], sfreq=100, befaft=np.array([1.,1.]), random_state=2)
-    new_out, stats_out = responsive_ttest(data=outstruct, resp='resp', sfreq='dataf', befaft='befaft', random_state=2)
+    new_resp, stats_resp = responsive_ttest(resp=outstruct['resp'], sfreq=100, befaft=np.array([1.,1.]))
+    new_out, stats_out = responsive_ttest(data=outstruct, resp='resp', sfreq='dataf', befaft='befaft')
 
     assert np.array_equal(new_resp[0], new_out[0]['resp'])
     assert np.array_equal(new_resp[1], new_out[1]['resp'])

--- a/tests/stats/test_responsive_elecs.py
+++ b/tests/stats/test_responsive_elecs.py
@@ -22,7 +22,22 @@ def test_responsive_ttest_picks_correct_electrode_from_outstruct(outstruct):
     new_out, stats = responsive_ttest(data=outstruct, resp='resp', sfreq='dataf', befaft='befaft', random_state=2)
     assert new_out[0]['resp'].shape[1] == 1
     assert np.array_equal(stats['significant'], np.array([0,1,0,0]).astype('bool'))
-    assert np.allclose(stats['stat'], np.array([-9.18367893e-01, -1.50768755e+02,  8.01840241e-02, -1.10738582e+00]), atol=1e-7)
+    assert np.allclose(stats['stat'], np.array([-1.67113052, -63.20943622,   0.23296204,  -1.78460185]), atol=1e-7)
+    assert np.allclose(stats['pval'], np.array([1.26958793e-001, 2.51319873e-266, 8.15870594e-001, 1.26958793e-001]), atol=1e-7)
+
+def test_responsive_ttest_picks_correct_electrode_from_outstruct_alternative_less(outstruct):
+    new_out, stats = responsive_ttest(data=outstruct, resp='resp', sfreq='dataf', befaft='befaft', random_state=2, alternative='less')
+    assert new_out[0]['resp'].shape[1] == 1
+    assert np.array_equal(stats['significant'], np.array([0,1,0,0]).astype('bool'))
+    assert np.allclose(stats['stat'], np.array([-1.67113052, -63.20943622,   0.23296204,  -1.78460185]), atol=1e-7)
+    assert np.allclose(stats['pval'], np.array([6.34793965e-002, 1.25659937e-266, 5.92064703e-001, 6.34793965e-002]), atol=1e-7)
+
+def test_responsive_ttest_picks_correct_electrode_from_outstruct_alternative_greater(outstruct):
+    new_out, stats = responsive_ttest(data=outstruct, resp='resp', sfreq='dataf', befaft='befaft', random_state=2, alternative='greater')
+    assert new_out[0]['resp'].shape[1] == 0
+    assert np.array_equal(stats['significant'], np.array([0,0,0,0]).astype('bool'))
+    assert np.allclose(stats['stat'], np.array([-1.67113052, -63.20943622,   0.23296204,  -1.78460185]), atol=1e-7)
+    assert np.allclose(stats['pval'], np.array([1., 1., 1., 1.]), atol=1e-7)
 
 def test_responsive_ttest_picks_correct_electrode_pass_args_individually_vs_outstruct_same(outstruct):
     new_resp, stats_resp = responsive_ttest(resp=outstruct['resp'], sfreq=100, befaft=np.array([1.,1.]), random_state=2)


### PR DESCRIPTION
<!--
Thanks for contributing a pull request to naplib-python!
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.
Fix an issue with the computation of t-test statistics for the responsive t-test whereby inconsistent results would be achieved when performing the test on data where each trial had different scales or average values. This would cause each trial, and each retest, to have highly variable test statistics, so especially when using a specific alternative, like "greater" or "less", it was possible for the test to be significant even if the test statistic (after averaging over all trials and retests) to be the wrong sign which indicated that it couldn't possibly be significant.

#### Any other comments?
Also fixes a bug in process_ieeg that was causing a failure for python 3.9+
