### PR TITLE
add shift_label_onsets function

### DIFF
--- a/docs/references/segmentation.rst
+++ b/docs/references/segmentation.rst
@@ -16,6 +16,11 @@ Segment Around Label Transitions
 .. minigallery:: naplib.segmentation.segment_around_label_transitions
         :add-heading: Examples using ``segment_around_label_transitions ``
 
+Shift Label Onsets
+------------------
+
+.. autofunction:: shift_label_onsets
+
 Electrode Lags from F-Ratio
 ---------------------------
 

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -4,7 +4,7 @@ ipython>=7.4
 ipykernel>=5.1.0
 numpydoc>=1.1.0
 recommonmark==0.5.0
-pyyaml
+pyyaml>=5.1
 TextGrid
 sphinx-gallery==0.10.1
 openneuro-py==2022.4.0

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -4,7 +4,8 @@ ipython>=7.4
 ipykernel>=5.1.0
 numpydoc>=1.1.0
 recommonmark==0.5.0
-pyyaml>=5.1
+ruamel.yaml==0.17.32
+pyyaml
 TextGrid
 sphinx-gallery==0.10.1
 openneuro-py==2022.4.0

--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -4,9 +4,6 @@ ipython>=7.4
 ipykernel>=5.1.0
 numpydoc>=1.1.0
 recommonmark==0.5.0
-ruamel.yaml==0.17.32
-pyyaml
-TextGrid
 sphinx-gallery==0.10.1
 openneuro-py==2022.4.0
 mne-bids==0.11.1

--- a/naplib/__init__.py
+++ b/naplib/__init__.py
@@ -44,5 +44,5 @@ import naplib.utils
 from .data import Data, join_fields, concat
 import naplib.naplab
 
-__version__ = "1.1.0"
+__version__ = "1.2.0"
 

--- a/naplib/array_ops/operations.py
+++ b/naplib/array_ops/operations.py
@@ -21,7 +21,7 @@ def sliding_window(arr, window_len, window_key_idx=0, fill_out_of_bounds=True, f
     
     Parameters
     ----------
-    arr : np.ndarray, shape (time, *feature_dims)
+    arr : np.ndarray, shape (time, feature_dims...)
         Data to be windowed. Windowing is only applied across first dimension,
         which is assumed to be time. All other dimensions are kept the same for
         the output.
@@ -49,7 +49,7 @@ def sliding_window(arr, window_len, window_key_idx=0, fill_out_of_bounds=True, f
     
     Returns
     -------
-    windows : np.ndarray, shape (n_samples, window_len, *feature_dims...)
+    windows : np.ndarray, shape (n_samples, window_len, feature_dims...)
         Windowed array segments.
     
     

--- a/naplib/io/load_nwb.py
+++ b/naplib/io/load_nwb.py
@@ -1,6 +1,6 @@
 from typing import Dict
 import numpy as np
-from pynwb import NWBHDF5IO
+
 
 def load_nwb(filepath: str) -> Dict:
     """
@@ -18,6 +18,12 @@ def load_nwb(filepath: str) -> Dict:
         'wav' - loaded audio recording (time*channels), wav_f' - sampling rate of sound,
         'labels' - array of labels for the channel streams
     """
+
+    try:
+        from pynwb import NWBHDF5IO
+    except Exception:
+        raise Exception('Missing package pynwb which is required for loading data from NWB format. Please '
+            'install it with "pip install pynwb"')
 
     with NWBHDF5IO(filepath, "r") as reader:
         loaded_data = reader.read()

--- a/naplib/naplab/alignment.py
+++ b/naplib/naplab/alignment.py
@@ -10,7 +10,8 @@ from naplib import logger
 def align_stimulus_to_recording(rec_audio, rec_fs, stim_dict, stim_order,
     use_hilbert=True, confidence_threshold=0.2, t_search=120, t_start_look=0):
     '''
-    Find the times that correspond to the start and end time of each stimulus
+    Find the times that correspond to the start and end time of each stimulus.
+
     Parameters
     ----------
     rec_audio : np.ndarray of shape (time,)

--- a/naplib/naplab/process_ieeg.py
+++ b/naplib/naplab/process_ieeg.py
@@ -54,6 +54,10 @@ def process_ieeg(
     n_jobs: int=1,
 ):
     """
+    Process raw iEEG data.
+
+    Parameters
+    ----------
     data_path : str path-like
         String specifying data directory (for TDT) or file path for raw data file
     alignment_dir : str path-like

--- a/naplib/segmentation/__init__.py
+++ b/naplib/segmentation/__init__.py
@@ -1,5 +1,6 @@
 from .segmentation import get_label_change_points
 from .segmentation import segment_around_label_transitions
 from .segmentation import electrode_lags_fratio
+from .segmentation import shift_label_onsets
 
-__all__  = ['get_label_change_points','segment_around_label_transitions','electrode_lags_fratio']
+__all__  = ['get_label_change_points','segment_around_label_transitions','electrode_lags_fratio','shift_label_onsets']

--- a/naplib/segmentation/segmentation.py
+++ b/naplib/segmentation/segmentation.py
@@ -284,6 +284,6 @@ def shift_label_onsets(data=None, labels='wrd_labels', p=0.5):
             remove_samples = int(p*feature_length)
             new_labels_this_trial[loc:loc+remove_samples] = -1
 
-        new_labels.append(new_labels_this_trial)
+        new_labels.append(new_labels_this_trial[1:]) # remove extra -1 that we had prepended
     return new_labels
     

--- a/naplib/segmentation/segmentation.py
+++ b/naplib/segmentation/segmentation.py
@@ -277,7 +277,7 @@ def shift_label_onsets(data=None, labels='wrd_labels', p=0.5):
             if lab == -1:
                 continue
             if i == len(locs)-1:
-                feature_length = len(labels_this_trial) - loc
+                feature_length = len(labels_this_trial) - loc + 1
             else:
                 feature_length = locs[i+1] - loc
 

--- a/naplib/segmentation/segmentation.py
+++ b/naplib/segmentation/segmentation.py
@@ -1,5 +1,4 @@
 import numpy as np
-from naplib import Data
 from scipy.ndimage import gaussian_filter1d
 
 from ..stats import discriminability

--- a/naplib/segmentation/segmentation.py
+++ b/naplib/segmentation/segmentation.py
@@ -268,9 +268,10 @@ def shift_label_onsets(data=None, labels='wrd_labels', p=0.5):
     
     for labels_this_trial in labels:
         
-        new_labels_this_trial = labels_this_trial.copy()
+        new_labels_this_trial = labels_this_trial.copy().squeeze()
+        new_labels_this_trial = np.concatenate([np.array([-1]), new_labels_this_trial])
         
-        locs, labs, prior_labs = get_label_change_points(labels_this_trial)
+        locs, labs, prior_labs = get_label_change_points(new_labels_this_trial)
 
         for i, (loc, lab, prior_lab) in enumerate(zip(locs, labs, prior_labs)):
             if lab == -1:

--- a/naplib/stats/mixedeffectsmodel.py
+++ b/naplib/stats/mixedeffectsmodel.py
@@ -65,7 +65,7 @@ class LinearMixedEffectsModel():
             
         Returns
         -------
-            model : returns an instance of self
+        model : returns an instance of self
         '''
         if random_effect is not None:
             if random_effect.ndim == 1:

--- a/naplib/visualization/plots.py
+++ b/naplib/visualization/plots.py
@@ -152,9 +152,11 @@ def kde_plot(data, groupings=None, hist=True, alpha=0.2, bins=None, **kwargs):
                          f' but got {len(color)} colors and {num_unique} groups')
 
     # loop through groups
+    color_cycle_default = plt.rcParams["axes.prop_cycle"].by_key()["color"]
+    len_cycle = len(color_cycle)
     for i, grp in enumerate(sorted(np.unique(df['group'].values))):
         if color[i] is None:
-            col = next(ax._get_lines.prop_cycler)['color']
+            col = color_cycle_default[i%len_cycle] #next(ax._get_lines.prop_cycler)['color']
         else:
             col = color[i]
 
@@ -340,7 +342,7 @@ def shaded_error_plot(*args, ax=None, reduction='mean', err_method='stderr', col
 
     return ax
 
-def hierarchical_cluster_plot(data, axes=None, varnames=None, cmap='bwr', n_clusters=2):
+def hierarchical_cluster_plot(data, axes=None, varnames=None, cmap='bwr', n_clusters=2, metric='euclidean', linkage='ward'):
     '''
     Perform hierarchical clustering and plot dendrogram and clustered values as an
     image underneath. See Examples below for a depiction.
@@ -359,7 +361,13 @@ def hierarchical_cluster_plot(data, axes=None, varnames=None, cmap='bwr', n_clus
         colormap for the data plot
     n_clusters : int, default=2
         number of clusters which will be used when computing cluster labels that are returned
-    
+    metric : str, default='euclidean'
+        Distance metric. See scipy.spatial.distance.pdist for valid metrics.
+    linkage : str, default='ward'
+        Linkage method. Must be one of 'single','complete','average','weighted','centroid',
+        'median', or 'ward'. Some linkage methods are only valid for certain distance
+        metrics.
+
     Returns
     -------
     cluster_dict : dict
@@ -395,13 +403,13 @@ def hierarchical_cluster_plot(data, axes=None, varnames=None, cmap='bwr', n_clus
     else:
         return_axes = False
         
-    dend = shc.dendrogram(shc.linkage(data, method='ward'), show_leaf_counts=False, ax=axes[0], get_leaves=True, no_labels=True)
+    dend = shc.dendrogram(shc.linkage(data, method=linkage, metric=metric), show_leaf_counts=False, ax=axes[0], get_leaves=True, no_labels=True)
 
     axes[0].set_yticks([])
 
     leaves = dend['leaves']
 
-    cluster = AgglomerativeClustering(n_clusters=n_clusters, affinity='euclidean', linkage='ward')
+    cluster = AgglomerativeClustering(n_clusters=n_clusters, metric=metric, linkage=linkage)
     cluster_labels = cluster.fit_predict(data)
 
     if cmap=='bwr':

--- a/naplib/visualization/plots.py
+++ b/naplib/visualization/plots.py
@@ -153,7 +153,7 @@ def kde_plot(data, groupings=None, hist=True, alpha=0.2, bins=None, **kwargs):
 
     # loop through groups
     color_cycle_default = plt.rcParams["axes.prop_cycle"].by_key()["color"]
-    len_cycle = len(color_cycle)
+    len_cycle = len(color_cycle_default)
     for i, grp in enumerate(sorted(np.unique(df['group'].values))):
         if color[i] is None:
             col = color_cycle_default[i%len_cycle] #next(ax._get_lines.prop_cycler)['color']

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,8 @@ pandas>=1.0.0
 statsmodels>=0.13.0
 hdf5storage>=0.1.1
 seaborn>=0.12.0
-pyyaml>=5.1
+ruamel.yaml==0.17.32
+pyyaml
 TextGrid
 scikit-learn
 joblib

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,6 @@ pandas>=1.0.0
 statsmodels>=0.13.0
 hdf5storage>=0.1.1
 seaborn>=0.12.0
-ruamel.yaml==0.17.32
 pyyaml
 TextGrid
 scikit-learn
@@ -14,4 +13,3 @@ mne
 h5py
 patsy
 tdt>=0.5.0
-pynwb>=2.3.0

--- a/requirements.txt
+++ b/requirements.txt
@@ -5,7 +5,7 @@ pandas>=1.0.0
 statsmodels>=0.13.0
 hdf5storage>=0.1.1
 seaborn>=0.12.0
-pyyaml
+pyyaml>=5.1
 TextGrid
 scikit-learn
 joblib


### PR DESCRIPTION
<!--
Thanks for contributing a pull request to naplib-python!
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Fixes #183 

#### What does this implement/fix? Explain your changes.
Adds the ability to shift label vectors. This is useful when you have something like word labels from the word aligner, which those can only easily be used to align responses to word onsets/offsets, but you want something like word centers (i.e. 50% of the way through each word).

#### Any other comments?
Also fixes color cycle issue in kde_plot caused by change in matplotlib.

Also adds ability to change metric and linkage method in hierarchical_cluster_plot.
