### PR TITLE
Update changelog and sklearn version check in hierarchical_cluster_plot

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -28,6 +28,11 @@ Change tags (adopted from `sklearn <https://scikit-learn.org/stable/whats_new/v0
 
 - |API| : you will need to change your code to have the same effect in the future; or a feature will be removed in the future.
 
+Version 1.2.0
+-------------
+- |Enhancement| : Added the parameter ``makedirs`` to ``naplib.io.save`` to enable the automatic creation of directories in the path for the filename provided.
+- |Feature| : Added the function ``shift_label_onsets`` to ``naplib.segmentation`` which can be used to shift label vectors such as to segment data by word centers when only word onsets are aligned.
+
 Version 1.1.0
 -------------
 - |API| |FIX| : Added a ``pre_post`` argument to ``stats.responsive_ttest`` to allow greater flexibility to how the responsiveness test is conducted. Also fixed a minor issue with how the test was being computed.

--- a/naplib/visualization/plots.py
+++ b/naplib/visualization/plots.py
@@ -2,10 +2,12 @@ import warnings
 import numpy as np
 import pandas as pd
 import scipy.cluster.hierarchy as shc
+import sklearn
 from sklearn.cluster import AgglomerativeClustering
 import matplotlib.pyplot as plt
 from scipy import signal as sig
 import seaborn as sns
+from packaging import version
 
 
 def kde_plot(data, groupings=None, hist=True, alpha=0.2, bins=None, **kwargs):
@@ -409,7 +411,11 @@ def hierarchical_cluster_plot(data, axes=None, varnames=None, cmap='bwr', n_clus
 
     leaves = dend['leaves']
 
-    cluster = AgglomerativeClustering(n_clusters=n_clusters, metric=metric, linkage=linkage)
+    # The metric parameter is only available after sklearn 1.2.0. Before 1.2.0, it was called affinity
+    if version.parse(sklearn.__version__) < version.parse("1.2.0"):
+        cluster = AgglomerativeClustering(n_clusters=n_clusters, affinity=metric, linkage=linkage)
+    else:
+        cluster = AgglomerativeClustering(n_clusters=n_clusters, metric=metric, linkage=linkage)
     cluster_labels = cluster.fit_predict(data)
 
     if cmap=='bwr':

--- a/requirements.txt
+++ b/requirements.txt
@@ -13,3 +13,4 @@ mne
 h5py
 patsy
 tdt>=0.5.0
+packaging


### PR DESCRIPTION
<!--
Thanks for contributing a pull request to naplib-python!
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.
Update changeling for 1.2.0. 

Also, there is a call in naplib.visualization.hierarchical_cluster_plot where it calls sklearn.cluster.AgglomerativeClustering, but if sklearn version is <1.2 this fails because of a parameter name change that happened. However, I think requiring sklearn>=1.2 is too strict since the current version of sklearn is only 1.3, so I added a check to see what version of sklearn is being used and then change the parameter name that is called based on that.

#### Any other comments?
