### PR TITLE
Update responsive_ttest.py

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -28,6 +28,11 @@ Change tags (adopted from `sklearn <https://scikit-learn.org/stable/whats_new/v0
 
 - |API| : you will need to change your code to have the same effect in the future; or a feature will be removed in the future.
 
+Version 1.3.0
+-------------
+- |Feature| : Added the function ``peak_rate`` to ``naplib.features`` which can be used to extract peak rate events from an acoustic stimulus. See documentation for details.
+- |Enhancement| : Added the parameter ``average`` to ``naplib.stats.responsive_ttest`` to enable more robust t-test statistics when there are enough trials. See documentation for details.
+
 Version 1.2.0
 -------------
 - |Enhancement| : Added the parameter ``makedirs`` to ``naplib.io.save`` to enable the automatic creation of directories in the path for the filename provided.

--- a/naplib/__init__.py
+++ b/naplib/__init__.py
@@ -44,5 +44,5 @@ import naplib.utils
 from .data import Data, join_fields, concat
 import naplib.naplab
 
-__version__ = "1.2.0"
+__version__ = "1.3.0"
 

--- a/tests/stats/test_responsive_elecs.py
+++ b/tests/stats/test_responsive_elecs.py
@@ -25,6 +25,13 @@ def test_responsive_ttest_picks_correct_electrode_from_outstruct(outstruct):
     assert np.allclose(stats['stat'], np.array([-1.67113052, -63.20943622,   0.23296204,  -1.78460185]), atol=1e-7)
     assert np.allclose(stats['pval'], np.array([1.26958793e-001, 2.51319873e-266, 8.15870594e-001, 1.26958793e-001]), atol=1e-7)
 
+def test_responsive_ttest_picks_correct_electrode_from_outstruct_average_segment_windows(outstruct):
+    new_out, stats = responsive_ttest(data=outstruct, resp='resp', sfreq='dataf', befaft='befaft', average=True)
+    assert new_out[0].shape[1] == 1
+    assert np.array_equal(stats['significant'], np.array([0,1,0,0]).astype('bool'))
+    assert np.allclose(stats['stat'], np.array([-1.59007915, -5.28643157,  0.28904705, -1.57361706]), atol=1e-7)
+    assert np.allclose(stats['pval'], np.array([0.25424966, 0.02457324, 0.78690711, 0.25424966]), atol=1e-7)
+
 def test_responsive_ttest_picks_correct_electrode_from_outstruct_alternative_less(outstruct):
     new_out, stats = responsive_ttest(data=outstruct, resp='resp', sfreq='dataf', befaft='befaft', alternative='less')
     assert new_out[0].shape[1] == 1


### PR DESCRIPTION
<!--
Thanks for contributing a pull request to naplib-python!
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Fixes #188 

#### What does this implement/fix? Explain your changes.
Adds a parameter to average segment responses within windows before computing t-test for responsive electrodes.

#### Any other comments?
