### PR TITLE
Add resample_categorical and forward_fill functions to array_ops module

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -32,6 +32,7 @@ Version 1.3.0
 -------------
 - |Feature| : Added the function ``peak_rate`` to ``naplib.features`` which can be used to extract peak rate events from an acoustic stimulus. See documentation for details.
 - |Feature| : Added the function ``resample_categorical`` to ``naplib.array_ops`` which can be used to resample categorical data.
+- |Feature| : Added the function ``forward_fill`` to ``naplib.array_ops`` for fast forward-filling of nan values in an array.
 - |Enhancement| : Added the parameter ``average`` to ``naplib.stats.responsive_ttest`` to enable more robust t-test statistics when there are enough trials. See documentation for details.
 
 Version 1.2.0

--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -31,6 +31,7 @@ Change tags (adopted from `sklearn <https://scikit-learn.org/stable/whats_new/v0
 Version 1.3.0
 -------------
 - |Feature| : Added the function ``peak_rate`` to ``naplib.features`` which can be used to extract peak rate events from an acoustic stimulus. See documentation for details.
+- |Feature| : Added the function ``resample_categorical`` to ``naplib.array_ops`` which can be used to resample categorical data.
 - |Enhancement| : Added the parameter ``average`` to ``naplib.stats.responsive_ttest`` to enable more robust t-test statistics when there are enough trials. See documentation for details.
 
 Version 1.2.0

--- a/docs/references/array_ops.rst
+++ b/docs/references/array_ops.rst
@@ -17,3 +17,8 @@ Resample Categorical Data
 -------------------------
 
 .. autofunction:: resample_categorical
+
+Forward Fill
+------------
+
+.. autofunction:: forward_fill

--- a/docs/references/array_ops.rst
+++ b/docs/references/array_ops.rst
@@ -12,3 +12,8 @@ Concatenate and Apply
 ---------------------
 
 .. autofunction:: concat_apply
+
+Resample Categorical Data
+-------------------------
+
+.. autofunction:: resample_categorical

--- a/naplib/array_ops/__init__.py
+++ b/naplib/array_ops/__init__.py
@@ -1,3 +1,3 @@
-from .operations import sliding_window, concat_apply
+from .operations import sliding_window, concat_apply, resample_categorical
 
-__all__ = ['sliding_window','concat_apply']
+__all__ = ['sliding_window','concat_apply','resample_categorical']

--- a/naplib/array_ops/__init__.py
+++ b/naplib/array_ops/__init__.py
@@ -1,3 +1,3 @@
-from .operations import sliding_window, concat_apply, resample_categorical
+from .operations import sliding_window, concat_apply, resample_categorical, forward_fill
 
-__all__ = ['sliding_window','concat_apply','resample_categorical']
+__all__ = ['sliding_window','concat_apply','resample_categorical','forward_fill']

--- a/naplib/array_ops/operations.py
+++ b/naplib/array_ops/operations.py
@@ -3,13 +3,13 @@ import numpy as np
 from .. import logger
 from ..segmentation import get_label_change_points
 
-def resample_categorical(x, num):
+def resample_categorical(arr, num):
     """
     Resample categorical data (i.e. integers) to a new size
     
     Parameters
     ----------
-    x : np.ndarray
+    arr : np.ndarray
         Array to be resampled. Either shape (time,) or shape (time, features).
         Will resample along axis=0. Each feature is resampled independently. 
     num : int
@@ -17,7 +17,7 @@ def resample_categorical(x, num):
     
     Returns
     -------
-    resamp_x : np.ndarray
+    resamp_arr : np.ndarray
         Resampled data. Length = ``num``
     
     Examples
@@ -33,17 +33,17 @@ def resample_categorical(x, num):
        5., 5., 5.])
     """
     
-    if x.ndim > 2:
+    if arr.ndim > 2:
         raise ValueError(f'x must be at most 2D but got x of shape {x.shape}')
-    if x.ndim == 2:
-        resamp_x = []
-        for col in x.T:
-            resamp_x.append(_resample_1d_categorical(col, num))
-        resamp_x = np.vstack(resamp_x).T
+    if arr.ndim == 2:
+        resamp_arr = []
+        for col in arr.T:
+            resamp_arr.append(_resample_1d_categorical(col, num))
+        resamp_arr = np.vstack(resamp_arr).T
     else:
-        resamp_x = _resample_1d_categorical(x, num)
+        resamp_arr = _resample_1d_categorical(arr, num)
 
-    return resamp_x
+    return resamp_arr
             
             
             

--- a/naplib/array_ops/operations.py
+++ b/naplib/array_ops/operations.py
@@ -41,7 +41,7 @@ def resample_categorical(x, num):
             resamp_x.append(_resample_1d_categorical(col, num))
         resamp_x = np.vstack(resamp_x).T
     else:
-        resamp_x = _resample_1d_categorical_simple(x, num)
+        resamp_x = _resample_1d_categorical(x, num)
 
     return resamp_x
             

--- a/naplib/array_ops/operations.py
+++ b/naplib/array_ops/operations.py
@@ -34,7 +34,7 @@ def resample_categorical(arr, num):
     """
     
     if arr.ndim > 2:
-        raise ValueError(f'x must be at most 2D but got x of shape {x.shape}')
+        raise ValueError(f'arr must be at most 2D but got arr of shape {arr.shape}')
     if arr.ndim == 2:
         resamp_arr = []
         for col in arr.T:

--- a/naplib/array_ops/operations.py
+++ b/naplib/array_ops/operations.py
@@ -127,6 +127,9 @@ def forward_fill(arr, axis=0):
             raise ValueError(f'Got 1D input but axis is not 0 for forward fill.')
     else:
         flag_1d = False
+    if axis > 1:
+        raise ValueError(f'Axis must be either 0 or 1 but got {axis}')
+
     arr = np.swapaxes(arr, 1, axis)
     mask = np.isnan(arr)
     idx = np.where(~mask, np.arange(mask.shape[1]), 0)

--- a/tests/array_ops/test_forward_fill.py
+++ b/tests/array_ops/test_forward_fill.py
@@ -14,7 +14,7 @@ def test_forward_fill_axis0():
                        [ 2.,  1.,  3., np.nan],
                        [ 2.,  1.,  3., np.nan]])
   output = forward_fill(arr, axis=0)
-  assert np.allclose(output, expected)
+  assert np.allclose(output, expected, equal_nan=True)
 
 def test_forward_fill_axis1():
   arr = np.nan*np.ones((5,4))
@@ -27,15 +27,15 @@ def test_forward_fill_axis1():
                        [np.nan, np.nan, np.nan, np.nan],
                        [np.nan, np.nan, np.nan, np.nan]])
   output = forward_fill(arr, axis=1)
-  assert np.allclose(output, expected)
+  assert np.allclose(output, expected, equal_nan=True)
 
 def test_forward_fill_1d():
   arr = np.nan*np.ones((6,))
   arr[1] = 1
-  arr[3,0] = 2
+  arr[3] = 2
   expected = np.array([np.nan,1,1,2,2,2])
   output = forward_fill(arr, axis=0)
-  assert np.allclose(output, expected)
+  assert np.allclose(output, expected, equal_nan=True)
 
 def test_bad_input():
   arr = np.nan*np.ones((5,4))

--- a/tests/array_ops/test_forward_fill.py
+++ b/tests/array_ops/test_forward_fill.py
@@ -1,0 +1,49 @@
+import pytest
+import numpy as np
+
+from naplib.array_ops import forward_fill
+
+def test_forward_fill_axis0():
+  arr = np.nan*np.ones((5,4))
+  arr[0,1] = 1
+  arr[2,0] = 2
+  arr[2,2] = 3
+  expected = np.array([[nan,  1., nan, nan],
+                       [nan,  1., nan, nan],
+                       [ 2.,  1.,  3., nan],
+                       [ 2.,  1.,  3., nan],
+                       [ 2.,  1.,  3., nan]])
+  output = forward_fill(arr, axis=0)
+  assert np.allclose(output, expected)
+
+def test_forward_fill_axis1():
+  arr = np.nan*np.ones((5,4))
+  arr[0,1] = 1
+  arr[2,0] = 2
+  arr[2,2] = 3
+  expected = np.array([[nan,  1.,  1.,  1.],
+                       [nan, nan, nan, nan],
+                       [ 2.,  2.,  3.,  3.],
+                       [nan, nan, nan, nan],
+                       [nan, nan, nan, nan]])
+  output = forward_fill(arr, axis=1)
+  assert np.allclose(output, expected)
+
+def test_forward_fill_1d():
+  arr = np.nan*np.ones((6,))
+  arr[1] = 1
+  arr[3,0] = 2
+  expected = np.array([np.nan,1,1,2,2,2])
+  output = forward_fill(arr, axis=0)
+  assert np.allclose(output, expected)
+
+def test_bad_input():
+  arr = np.nan*np.ones((5,4))
+  arr[0,1] = 1
+  arr[2,0] = 2
+  arr[2,2] = 3
+  with pytest.raises(ValueError) as err:
+    _ = forward_fill(arr, axis=2)
+  assert 'Axis must be either 0 or 1 but got 2' in str(err)
+    
+  

--- a/tests/array_ops/test_forward_fill.py
+++ b/tests/array_ops/test_forward_fill.py
@@ -8,11 +8,11 @@ def test_forward_fill_axis0():
   arr[0,1] = 1
   arr[2,0] = 2
   arr[2,2] = 3
-  expected = np.array([[nan,  1., nan, nan],
-                       [nan,  1., nan, nan],
-                       [ 2.,  1.,  3., nan],
-                       [ 2.,  1.,  3., nan],
-                       [ 2.,  1.,  3., nan]])
+  expected = np.array([[np.nan,  1., np.nan, np.nan],
+                       [np.nan,  1., np.nan, np.nan],
+                       [ 2.,  1.,  3., np.nan],
+                       [ 2.,  1.,  3., np.nan],
+                       [ 2.,  1.,  3., np.nan]])
   output = forward_fill(arr, axis=0)
   assert np.allclose(output, expected)
 
@@ -21,11 +21,11 @@ def test_forward_fill_axis1():
   arr[0,1] = 1
   arr[2,0] = 2
   arr[2,2] = 3
-  expected = np.array([[nan,  1.,  1.,  1.],
-                       [nan, nan, nan, nan],
+  expected = np.array([[np.nan,  1.,  1.,  1.],
+                       [np.nan, np.nan, np.nan, np.nan],
                        [ 2.,  2.,  3.,  3.],
-                       [nan, nan, nan, nan],
-                       [nan, nan, nan, nan]])
+                       [np.nan, np.nan, np.nan, np.nan],
+                       [np.nan, np.nan, np.nan, np.nan]])
   output = forward_fill(arr, axis=1)
   assert np.allclose(output, expected)
 

--- a/tests/array_ops/test_resample_categorical.py
+++ b/tests/array_ops/test_resample_categorical.py
@@ -10,7 +10,7 @@ LOGGER = logging.getLogger(__name__)
 def test_too_few_samples(caplog):
     caplog.set_level(logging.WARNING)
     x = np.array([1,1,1,1,2,2,3,3,4,4,4,4,5,5,5,5])
-    resample_categorical(x, num=6)
+    new = resample_categorical(x, num=6)
     assert 'New labels are not equivalent to the old labels' in caplog.text
     expected = np.array([1., 1., 3., 4., 5., 5.])
     assert np.allclose(new, expected)

--- a/tests/array_ops/test_resample_categorical.py
+++ b/tests/array_ops/test_resample_categorical.py
@@ -26,3 +26,38 @@ def test_upsample():
     new = resample_categorical(x, num=20)
     expected = np.array([1., 1., 1., 1., 1., 2., 2., 2., 3., 3., 4., 4., 4., 4., 4., 5., 5., 5., 5., 5.])
     assert np.allclose(new, expected)
+
+def test_downsample_2d():
+    x = np.reshape([1,1,1,1,1,2,2,2,2,3,3,3,3,3,3,3,3,3,4,4,4,4,4,4],(12,2))
+    new = resample_categorical(x, num=7)
+    expected = np.array([[1., 1.],[1., 2.],[2., 3.],[3., 3.],[3., 3.],[4., 4.],[4., 4.]])
+    assert np.allclose(new, expected)
+
+def test_upsample_2d():
+    x = np.reshape([1,1,1,1,1,2,2,2,2,3,3,3,3,3,3,3,3,3,4,4,4,4,4,4],(12,2))
+    new = resample_categorical(x, num=24)
+    expected = np.array([[1., 1.],
+       [1., 1.],
+       [1., 1.],
+       [1., 1.],
+       [1., 2.],
+       [1., 2.],
+       [2., 2.],
+       [2., 2.],
+       [2., 3.],
+       [2., 3.],
+       [3., 3.],
+       [3., 3.],
+       [3., 3.],
+       [3., 3.],
+       [3., 3.],
+       [3., 3.],
+       [3., 3.],
+       [3., 3.],
+       [4., 4.],
+       [4., 4.],
+       [4., 4.],
+       [4., 4.],
+       [4., 4.],
+       [4., 4.]])
+    assert np.allclose(new, expected)

--- a/tests/array_ops/test_resample_categorical.py
+++ b/tests/array_ops/test_resample_categorical.py
@@ -1,0 +1,26 @@
+import pytest
+import numpy as np
+
+from naplib.array_ops import resample_categorical
+
+LOGGER = logging.getLogger(__name__)
+
+def test_too_few_samples(caplog):
+    caplog.set_level(logging.WARNING)
+    x = np.array([1,1,1,1,2,2,3,3,4,4,4,4,5,5,5,5])
+    resample_categorical(x, num=6)
+    assert 'New labels are not equivalent to the old labels' in caplog.text
+    expected = np.array([1., 1., 3., 4., 5., 5.])
+    assert np.allclose(new, expected)
+
+def test_downsample():
+    x = np.array([1,1,1,1,2,2,3,3,4,4,4,4,5,5,5,5])
+    new = resample_categorical(x, num=8)
+    expected = np.array([1., 1., 2., 3., 4., 4., 5., 5.])
+    assert np.allclose(new, expected)
+
+def test_upsample():
+    x = np.array([1,1,1,1,2,2,3,3,4,4,4,4,5,5,5,5])
+    new = resample_categorical(x, num=20)
+    expected = np.array([1., 1., 1., 1., 1., 2., 2., 2., 3., 3., 4., 4., 4., 4., 4., 5., 5., 5., 5., 5.])
+    assert np.allclose(new, expected)

--- a/tests/array_ops/test_resample_categorical.py
+++ b/tests/array_ops/test_resample_categorical.py
@@ -6,6 +6,7 @@ from naplib.array_ops import resample_categorical
 
 LOGGER = logging.getLogger(__name__)
 
+@pytest.mark.usefixtures("caplog")
 def test_too_few_samples(caplog):
     caplog.set_level(logging.WARNING)
     x = np.array([1,1,1,1,2,2,3,3,4,4,4,4,5,5,5,5])

--- a/tests/array_ops/test_resample_categorical.py
+++ b/tests/array_ops/test_resample_categorical.py
@@ -1,4 +1,5 @@
 import pytest
+import logging
 import numpy as np
 
 from naplib.array_ops import resample_categorical

--- a/tests/array_ops/test_resample_categorical.py
+++ b/tests/array_ops/test_resample_categorical.py
@@ -15,6 +15,11 @@ def test_too_few_samples(caplog):
     expected = np.array([1., 1., 3., 4., 5., 5.])
     assert np.allclose(new, expected)
 
+def test_bad_x_shape():
+    x = np.ones((12,3,4))
+    with pytest.raises(ValueError):
+        _ = resample_categorical(x, num=8)
+
 def test_downsample():
     x = np.array([1,1,1,1,2,2,3,3,4,4,4,4,5,5,5,5])
     new = resample_categorical(x, num=8)


### PR DESCRIPTION
<!--
Thanks for contributing a pull request to naplib-python!
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.
Add function to resample a categorical array. This is useful because standard resampling typically doesn't work on categorical values.

Also adds a forward_fill function for convenience.
