### PR TITLE
Update import_data to support struct rather than only struct array

### DIFF
--- a/docs/changelog.rst
+++ b/docs/changelog.rst
@@ -28,6 +28,11 @@ Change tags (adopted from `sklearn <https://scikit-learn.org/stable/whats_new/v0
 
 - |API| : you will need to change your code to have the same effect in the future; or a feature will be removed in the future.
 
+Version 1.4.0
+-------------
+- |Enhancement| : Added the ability to load outstructs from matlab which have different variable names, not just 'out'.
+- |Enhancement| : Improved the `naplib.io.export_data` function to the matlab outstruct by handling cases where fieldnames are strings characters like spaces which are not allowed in matlab struct field names.
+
 Version 1.3.0
 -------------
 - |Feature| : Added the function ``peak_rate`` to ``naplib.features`` which can be used to extract peak rate events from an acoustic stimulus. See documentation for details.

--- a/naplib/__init__.py
+++ b/naplib/__init__.py
@@ -44,5 +44,5 @@ import naplib.utils
 from .data import Data, join_fields, concat
 import naplib.naplab
 
-__version__ = "1.3.0"
+__version__ = "1.4.0"
 


### PR DESCRIPTION
<!--
Thanks for contributing a pull request to naplib-python!
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->
Fixes #191 

#### What does this implement/fix? Explain your changes.
Allows loading an out struct which was saved as a single struct (since it's only 1 trial) rather than the typical struct array.

#### Any other comments?
