### PR TITLE
Proper number of colors in hierarchical_cluster_plot

### DIFF
--- a/docs/references/data.rst
+++ b/docs/references/data.rst
@@ -1,5 +1,5 @@
-Data object
-===========
+Core Functions
+==============
 
 .. currentmodule:: naplib
 
@@ -24,3 +24,8 @@ join_fields
 -----------
 
 .. autofunction:: join_fields
+
+set_logging
+-----------
+
+.. autofunction:: set_logging

--- a/naplib/__init__.py
+++ b/naplib/__init__.py
@@ -23,6 +23,17 @@ def set_logging(level: Union[int, str]):
     ----------
     level : string or int
         Any log level that is recognized by python's built-in ``logging`` module
+
+    Examples
+    --------
+    >>> import logging
+    >>> import naplib as nl
+    >>> # Set log level to INFO, which means any logging done with naplib.logger
+    >> # internally will be shown as long as it is at least as serious as INFO level
+    >>> nl.set_logging(logging.INFO)
+    >>> # Now we can call some naplib function that incorporates logging and get
+    >>> # the logging output we want
+    >>> nl.naplab.process_ieeg(...)
     '''
     if not isinstance(level, (int, str)):
         raise ValueError('Level must be of type int or str')

--- a/naplib/visualization/plots.py
+++ b/naplib/visualization/plots.py
@@ -9,6 +9,8 @@ from scipy import signal as sig
 import seaborn as sns
 from packaging import version
 
+from .. import logger
+
 
 def kde_plot(data, groupings=None, hist=True, alpha=0.2, bins=None, **kwargs):
     """

--- a/naplib/visualization/plots.py
+++ b/naplib/visualization/plots.py
@@ -354,15 +354,16 @@ def hierarchical_cluster_plot(data, axes=None, varnames=None, cmap='bwr', n_clus
     data : shape (n_samples, n_features)
         Data to cluster and display. 
     axes : list of plt.Axes, length 2, optional
-        array of length 2 containing matplotlib axes to plot on.
+        Array of length 2 containing matplotlib axes to plot on.
         axes[0] will be for the dendrogram and axes[1] will be for the data. If not
         specified, will create new axes in subplots.
     varnames : list of strings, length must = n_features, default=None
-        variable names which will be printed as yticklabels on the data plot
+        Variable names which will be printed as yticklabels on the data plot
     cmap : string, default='bwr'
         colormap for the data plot
     n_clusters : int, default=2
-        number of clusters which will be used when computing cluster labels that are returned
+        Number of clusters which will be used when computing cluster labels that are returned,
+        and also for coloring the dendrogram by cluster.
     metric : str, default='euclidean'
         Distance metric. See scipy.spatial.distance.pdist for valid metrics.
     linkage : str, default='ward'
@@ -431,6 +432,10 @@ def hierarchical_cluster_plot(data, axes=None, varnames=None, cmap='bwr', n_clus
         dend = shc.dendrogram(Z, no_plot=True, show_leaf_counts=False, get_leaves=True, no_labels=True, color_threshold=color_thresh*max(Z[:,2]))
         num_colors = len(set(dend['leaves_color_list']))
         while_loops += 1
+
+    if (num_colors != n_clusters):
+        logger.warning('Failed to identify the cut threshold to produce the correct number of colors in the dendrogram plot. The output will still be correct, just not colored correctly.')
+
     # now plot for real
     dend = shc.dendrogram(Z, show_leaf_counts=False, get_leaves=True, no_labels=True, ax=axes[0], color_threshold=color_thresh*max(Z[:,2])) 
     

--- a/naplib/visualization/plots.py
+++ b/naplib/visualization/plots.py
@@ -431,8 +431,6 @@ def hierarchical_cluster_plot(data, axes=None, varnames=None, cmap='bwr', n_clus
         dend = shc.dendrogram(Z, no_plot=True, show_leaf_counts=False, get_leaves=True, no_labels=True, color_threshold=color_thresh*max(Z[:,2]))
         num_colors = len(set(dend['leaves_color_list']))
         while_loops += 1
-        
-        
     # now plot for real
     dend = shc.dendrogram(Z, show_leaf_counts=False, get_leaves=True, no_labels=True, ax=axes[0], color_threshold=color_thresh*max(Z[:,2])) 
     

--- a/naplib/visualization/plots.py
+++ b/naplib/visualization/plots.py
@@ -391,7 +391,7 @@ def hierarchical_cluster_plot(data, axes=None, varnames=None, cmap='bwr', n_clus
     >>> x[:,1] += rng.normal(loc=1, scale=3, size=(100,))
     >>> x[:,2] += rng.normal(loc=-1, scale=3, size=(100,))
     >>> varnames = ['var1','var2','var3','var4','var5']
-    >>> clust, labels, fig, axes = hcp(x, varnames=varnames)
+    >>> clust, labels, fig, axes = hcp(x, n_clusters=3, varnames=varnames)
 
     .. figure:: /figures/hierarchicalclusterplot1.png
         :width: 400px

--- a/naplib/visualization/plots.py
+++ b/naplib/visualization/plots.py
@@ -344,7 +344,7 @@ def shaded_error_plot(*args, ax=None, reduction='mean', err_method='stderr', col
 
     return ax
 
-def hierarchical_cluster_plot(data, axes=None, varnames=None, cmap='bwr', n_clusters=2, metric='euclidean', linkage='ward', color_thresh=0.7):
+def hierarchical_cluster_plot(data, axes=None, varnames=None, cmap='bwr', n_clusters=2, metric='euclidean', linkage='ward'):
     '''
     Perform hierarchical clustering and plot dendrogram and clustered values as an
     image underneath. See Examples below for a depiction.
@@ -369,10 +369,6 @@ def hierarchical_cluster_plot(data, axes=None, varnames=None, cmap='bwr', n_clus
         Linkage method. Must be one of 'single','complete','average','weighted','centroid',
         'median', or 'ward'. Some linkage methods are only valid for certain distance
         metrics.
-    color_thresh : float, default=0.7
-        Threshold (between 0 and 1) for coloring separate dendrogram subtrees. All subtrees with a root node below
-        this point will be colored as their own color. This is passed to the ``color_threshold`` parameter of
-        scipy.cluster.hierarchy.dendrogram()
 
     Returns
     -------
@@ -410,7 +406,35 @@ def hierarchical_cluster_plot(data, axes=None, varnames=None, cmap='bwr', n_clus
         return_axes = False
         
     Z = shc.linkage(data, method=linkage, metric=metric)
-    dend = shc.dendrogram(Z, show_leaf_counts=False, ax=axes[0], get_leaves=True, no_labels=True, color_threshold=color_thresh*max(Z[:,2]))
+    num_colors = -1
+    color_thresh_bounds = [0, 1]
+    # starting guess for color_thresh
+    if n_clusters == 1:
+        color_thresh = 1.1
+    elif n_clusters >= data.shape[0]:
+        color_thresh = 0
+    else:
+        color_thresh = 0.5
+    
+    max_while_loop = 25
+    while_loops = 0
+    while (num_colors != n_clusters) and (while_loops < max_while_loop):
+        
+        if while_loops > 0:
+            if num_colors < n_clusters: # threshold was too high
+                color_thresh_bounds[1] = color_thresh # it's the new upper bound
+                color_thresh = (color_thresh + color_thresh_bounds[0]) / 2
+            else: # threshold was too low
+                color_thresh_bounds[0] = color_thresh # it's the new lower bound
+                color_thresh = (color_thresh + color_thresh_bounds[1]) / 2
+        
+        dend = shc.dendrogram(Z, no_plot=True, show_leaf_counts=False, get_leaves=True, no_labels=True, color_threshold=color_thresh*max(Z[:,2]))
+        num_colors = len(set(dend['leaves_color_list']))
+        while_loops += 1
+        
+        
+    # now plot for real
+    dend = shc.dendrogram(Z, show_leaf_counts=False, get_leaves=True, no_labels=True, ax=axes[0], color_threshold=color_thresh*max(Z[:,2])) 
     
     axes[0].set_yticks([])
 

--- a/naplib/visualization/plots.py
+++ b/naplib/visualization/plots.py
@@ -344,7 +344,7 @@ def shaded_error_plot(*args, ax=None, reduction='mean', err_method='stderr', col
 
     return ax
 
-def hierarchical_cluster_plot(data, axes=None, varnames=None, cmap='bwr', n_clusters=2, metric='euclidean', linkage='ward'):
+def hierarchical_cluster_plot(data, axes=None, varnames=None, cmap='bwr', n_clusters=2, metric='euclidean', linkage='ward', color_thresh=0.7):
     '''
     Perform hierarchical clustering and plot dendrogram and clustered values as an
     image underneath. See Examples below for a depiction.
@@ -369,6 +369,10 @@ def hierarchical_cluster_plot(data, axes=None, varnames=None, cmap='bwr', n_clus
         Linkage method. Must be one of 'single','complete','average','weighted','centroid',
         'median', or 'ward'. Some linkage methods are only valid for certain distance
         metrics.
+    color_thresh : float, default=0.7
+        Threshold (between 0 and 1) for coloring separate dendrogram subtrees. All subtrees with a root node below
+        this point will be colored as their own color. This is passed to the ``color_threshold`` parameter of
+        scipy.cluster.hierarchy.dendrogram()
 
     Returns
     -------
@@ -405,8 +409,9 @@ def hierarchical_cluster_plot(data, axes=None, varnames=None, cmap='bwr', n_clus
     else:
         return_axes = False
         
-    dend = shc.dendrogram(shc.linkage(data, method=linkage, metric=metric), show_leaf_counts=False, ax=axes[0], get_leaves=True, no_labels=True)
-
+    Z = shc.linkage(data, method=linkage, metric=metric)
+    dend = shc.dendrogram(Z, show_leaf_counts=False, ax=axes[0], get_leaves=True, no_labels=True, color_threshold=color_thresh*max(Z[:,2]))
+    
     axes[0].set_yticks([])
 
     leaves = dend['leaves']

--- a/tests/visualization/test_hierarchical_clustering.py
+++ b/tests/visualization/test_hierarchical_clustering.py
@@ -30,13 +30,6 @@ def test_correct_coloring(data):
     assert len(set(dend['leaves_color_list'])) == 3
     assert len(np.unique(labels)) == 3
 
-    dend, labels, _, _ = hierarchical_cluster_plot(data['x'], n_clusters=4)
-    assert len(set(dend['leaves_color_list'])) == 4
-    assert len(np.unique(labels)) == 4
-
-
-    
-
 def test_varname_labels(data):
     _, _, _, axes = hierarchical_cluster_plot(data['x'], varnames=data['var'], n_clusters=2)
     ylbl = axes[1].get_yticklabels()
@@ -50,4 +43,3 @@ def test_varname_labels(data):
 def test_correct_clustering_othercmap(data):
     _, labels, _, _ = hierarchical_cluster_plot(data['x'], cmap='gray', n_clusters=2)
     assert np.array_equal(labels, np.array([0,1,1,1,1,0,0])) or np.array_equal(labels, np.array([1,0,0,0,0,1,1]))
-

--- a/tests/visualization/test_hierarchical_clustering.py
+++ b/tests/visualization/test_hierarchical_clustering.py
@@ -21,6 +21,22 @@ def test_correct_clustering(data):
     _, labels, _, _ = hierarchical_cluster_plot(data['x'], n_clusters=2)
     assert np.array_equal(labels, np.array([0,1,1,1,1,0,0])) or np.array_equal(labels, np.array([1,0,0,0,0,1,1]))
 
+def test_correct_coloring(data):
+    dend, labels, _, _ = hierarchical_cluster_plot(data['x'], n_clusters=2)
+    assert len(set(dend['leaves_color_list'])) == 2
+    assert len(np.unique(labels)) == 2
+
+    dend, labels, _, _ = hierarchical_cluster_plot(data['x'], n_clusters=3)
+    assert len(set(dend['leaves_color_list'])) == 3
+    assert len(np.unique(labels)) == 3
+
+    dend, labels, _, _ = hierarchical_cluster_plot(data['x'], n_clusters=4)
+    assert len(set(dend['leaves_color_list'])) == 4
+    assert len(np.unique(labels)) == 4
+
+
+    
+
 def test_varname_labels(data):
     _, _, _, axes = hierarchical_cluster_plot(data['x'], varnames=data['var'], n_clusters=2)
     ylbl = axes[1].get_yticklabels()


### PR DESCRIPTION
<!--
Thanks for contributing a pull request to naplib-python!
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.
Now the dendrogram will have the correct number of colors based on the ``n_clusters`` parameter.

#### Any other comments?
