### PR TITLE
Add example, Fix get_cmap

### DIFF
--- a/examples/brain_plotting/plot_intracranial_electrodes.py
+++ b/examples/brain_plotting/plot_intracranial_electrodes.py
@@ -123,7 +123,7 @@ fig, axes = plot_brain_overlay(brain, view='lateral')
 plt.show()
 
 ###############################################################################
-# Directly plot brain region labels overlaid on the brain
+# Directly plot Destrieux Atlas region labels overlaid on the brain
 brain = Brain('pial', subject_dir='./fsaverage/')
 
 brain.lh.overlay = brain.lh.labels

--- a/examples/brain_plotting/plot_intracranial_electrodes.py
+++ b/examples/brain_plotting/plot_intracranial_electrodes.py
@@ -122,4 +122,12 @@ brain.paint_overlay('MTG', 1)
 fig, axes = plot_brain_overlay(brain, view='lateral')
 plt.show()
 
+###############################################################################
+# Directly plot brain region labels overlaid on the brain
+brain = Brain('pial', subject_dir='./fsaverage/')
 
+brain.lh.overlay = brain.lh.labels
+brain.rh.overlay = brain.rh.labels
+
+fig, axes = plot_brain_overlay(brain, cmap='tab20', vmin=1, vmax=75)
+plt.show()

--- a/naplib/utils/surfdist.py
+++ b/naplib/utils/surfdist.py
@@ -180,7 +180,10 @@ def surfdist_viz(
 
     # if cmap is given as string, translate to matplotlib cmap
     if isinstance(cmap, str):
-        cmap = plt.cm.get_cmap(cmap)
+        try:
+            cmap = plt.cm.get_cmap(cmap)
+        except AttributeError:
+            cmap = plt.get_cmap(cmap)
 
     if ax is None:
         premade_ax = False


### PR DESCRIPTION
Add to the example of plotting on the brain by plotting the atlas regions on the brain.

Catch an exception caused by matplotlib 3.9 breaking plt.cm.get_cmap() and replacing it with plt.get_cmap()<!--
Thanks for contributing a pull request to naplib-python!
-->

#### Reference Issues/PRs


#### What does this implement/fix? Explain your changes.
Fixed break in matplotlib 3.9 plt.cm.get_cmap() deprecated
Added example

#### Any other comments?
Add to the example of plotting on the brain by plotting the atlas regions on the brain.

Catch an exception caused by matplotlib 3.9 breaking plt.cm.get_cmap() and replacing it with plt.get_cmap()Add to the example of plotting on the brain by plotting the atlas regions on the brain.

Catch an exception caused by matplotlib 3.9 breaking plt.cm.get_cmap() and replacing it with plt.get_cmap()