### PR TITLE
Fix docs auto-build error

### DIFF
--- a/docs/requirements.txt
+++ b/docs/requirements.txt
@@ -8,3 +8,4 @@ sphinx-gallery==0.10.1
 mne<1.5 # for building docs, since mne-bids is needed, must have lower version of mne https://github.com/mne-tools/mne-python/pull/11582/files
 openneuro-py==2022.4.0
 mne-bids==0.11.1
+nbformat>=4.2.0


### PR DESCRIPTION
<!--
Thanks for contributing a pull request to naplib-python!
-->

#### Reference Issues/PRs
<!--
Example: Fixes #1234. See also #3456.
Please use keywords (e.g., Fixes) to create link to the issues or pull requests
you resolved, so that they will automatically be closed when your pull request
is merged. See https://github.com/blog/1506-closing-issues-via-pull-requests
-->


#### What does this implement/fix? Explain your changes.
Docs auto-build on PRs are failing, so this adds a requirement for nbformat to the docs generation.

#### Any other comments?
