### PR TITLE
Create sulcus alpha and light source for brain plots

### DIFF
--- a/naplib/localization/freesurfer.py
+++ b/naplib/localization/freesurfer.py
@@ -121,10 +121,10 @@ class Hemisphere:
     
         try:
             self.sulc = read_morph_data(self.surf_file(f"{hemi}.sulc"))
-            self.sulc_alpha = 1.0
         except Exception as e:
             logger.warning(f'No {hemi}.sulc file found. No sulcus information will be used.')
             self.sulc = None
+        self.sulc_alpha = 1.0
 
 
         self.load_labels()

--- a/naplib/localization/freesurfer.py
+++ b/naplib/localization/freesurfer.py
@@ -124,6 +124,7 @@ class Hemisphere:
         except Exception as e:
             logger.warning(f'No {hemi}.sulc file found. No sulcus information will be used.')
             self.sulc = None
+        self.sulc_alpha = 1.0
 
 
         self.load_labels()

--- a/naplib/localization/freesurfer.py
+++ b/naplib/localization/freesurfer.py
@@ -121,10 +121,10 @@ class Hemisphere:
     
         try:
             self.sulc = read_morph_data(self.surf_file(f"{hemi}.sulc"))
+            self.sulc_alpha = 1.0
         except Exception as e:
             logger.warning(f'No {hemi}.sulc file found. No sulcus information will be used.')
             self.sulc = None
-        self.sulc_alpha = 1.0
 
 
         self.load_labels()

--- a/naplib/utils/surfdist.py
+++ b/naplib/utils/surfdist.py
@@ -124,6 +124,7 @@ def surfdist_viz(
     alpha="auto",
     bg_map=None,
     bg_on_stat=False,
+    bg_alpha=1.0,
     figsize=None,
     ax=None,
     vmin=None,
@@ -158,6 +159,8 @@ def surfdist_viz(
                  multiplied with the background map for shadowing. Otherwise,
                  only areas that are not covered by the statsitical map after
                  thresholding will show shadows.
+    bg_alpha : float, determines the opacity of the background map.
+               bg_alpha defaults to 1.0 and is only relevant if bg_on_stat
     figsize : tuple of intergers, dimensions of the figure that is produced.
     ax : Axis
         Axis to plot on, with 3d projection.
@@ -226,7 +229,7 @@ def surfdist_viz(
             bg_faces = np.mean(bg_data[faces], axis=1)
             bg_faces = bg_faces - bg_faces.min()
             bg_faces = bg_faces / bg_faces.max()
-            face_colors = plt.cm.gray_r(bg_faces)
+            face_colors = plt.cm.gray_r(bg_faces * bg_alpha)
 
         # modify alpha values of background
         face_colors[:, 3] = alpha * face_colors[:, 3]

--- a/naplib/visualization/brain_plots.py
+++ b/naplib/visualization/brain_plots.py
@@ -90,7 +90,7 @@ def _view(hemi, mode: str = "lateral", backend: str = "mpl"):
     raise ValueError(f"Unknown `mode`: {mode}.")
 
 
-def _plot_hemi(hemi, cmap="coolwarm", ax=None, view="best", threshold=None, vmin=None, vmax=None, light_source=True):
+def _plot_hemi(hemi, cmap="coolwarm", ax=None, view="best", threshold=None, vmin=None, vmax=None, light_source=False):
     if isinstance(view, tuple):
         elev, azim = view
     else:
@@ -116,7 +116,7 @@ def _plot_hemi(hemi, cmap="coolwarm", ax=None, view="best", threshold=None, vmin
 
 
 def plot_brain_overlay(
-    brain, cmap="coolwarm", ax=None, hemi='both', view="best", vmin=None, vmax=None, cmap_quantile=1.0, threshold=None, light_source=True, **kwargs
+    brain, cmap="coolwarm", ax=None, hemi='both', view="best", vmin=None, vmax=None, cmap_quantile=1.0, threshold=None, light_source=False, **kwargs
 ):
     """
     Plot brain overlay on the 3D cortical surface using matplotlib.

--- a/naplib/visualization/brain_plots.py
+++ b/naplib/visualization/brain_plots.py
@@ -105,6 +105,7 @@ def _plot_hemi(hemi, cmap="coolwarm", ax=None, view="best", threshold=None, vmin
         alpha=hemi.alpha,
         bg_map=hemi.sulc,
         bg_on_stat=True,
+        bg_alpha=hemi.sulc_alpha,
         ax=ax,
         vmin=vmin,
         vmax=vmax

--- a/naplib/visualization/brain_plots.py
+++ b/naplib/visualization/brain_plots.py
@@ -90,7 +90,7 @@ def _view(hemi, mode: str = "lateral", backend: str = "mpl"):
     raise ValueError(f"Unknown `mode`: {mode}.")
 
 
-def _plot_hemi(hemi, cmap="coolwarm", ax=None, view="best", threshold=None, vmin=None, vmax=None):
+def _plot_hemi(hemi, cmap="coolwarm", ax=None, view="best", threshold=None, vmin=None, vmax=None, light_source=True):
     if isinstance(view, tuple):
         elev, azim = view
     else:
@@ -108,14 +108,15 @@ def _plot_hemi(hemi, cmap="coolwarm", ax=None, view="best", threshold=None, vmin
         bg_alpha=hemi.sulc_alpha,
         ax=ax,
         vmin=vmin,
-        vmax=vmax
+        vmax=vmax,
+        light_source=light_source
     )
     ax.axes.set_axis_off()
     ax.grid(False)
 
 
 def plot_brain_overlay(
-    brain, cmap="coolwarm", ax=None, hemi='both', view="best", vmin=None, vmax=None, cmap_quantile=1.0, threshold=None, **kwargs
+    brain, cmap="coolwarm", ax=None, hemi='both', view="best", vmin=None, vmax=None, cmap_quantile=1.0, threshold=None, light_source=True, **kwargs
 ):
     """
     Plot brain overlay on the 3D cortical surface using matplotlib.
@@ -150,6 +151,11 @@ def plot_brain_overlay(
     threshold : positive float, optional
         If given, then only values on the overlay which are less -threshold or greater than threshold will
         be shown.
+    light_source: None, bool, or tuple of int, optional
+        Whether to apply a light source for shading. If True, the light
+        source position is inferred from `elev` and `azim`. If a tuple of
+        (alt, az), these values will be used to specify the light source
+        position. If None or False, no shading is applied. Default is True.
     **kwargs : kwargs
         Any other kwargs to pass to matplotlib.pyplot.figure (such as figsize)
 
@@ -217,9 +223,9 @@ def plot_brain_overlay(
     
             
     if ax[0] is not None:
-        _plot_hemi(brain.lh, cmap, ax[0], view=view, vmin=vmin, vmax=vmax, threshold=threshold)
+        _plot_hemi(brain.lh, cmap, ax[0], view=view, vmin=vmin, vmax=vmax, threshold=threshold, light_source=light_source)
     if ax[1] is not None:
-        _plot_hemi(brain.rh, cmap, ax[1], view=view, vmin=vmin, vmax=vmax, threshold=threshold)
+        _plot_hemi(brain.rh, cmap, ax[1], view=view, vmin=vmin, vmax=vmax, threshold=threshold, light_source=light_source)
 
     return fig, ax
 


### PR DESCRIPTION
#### What does this implement/fix? Explain your changes.
Allows the user to manually set the alpha transparency of the background of brain plot.
This is useful for making the sulci and gyri coloring less prominent, so they don't distract from colormap differences.

#### Any other comments?
